### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/copystring/ioBroker.roborock.git"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
Adapter-core 3.x.x is known to fail when installed at node 14 or lower as npm 7 deos not install peerDependencies. So this adapter requires node 16 or newer