### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/copystring/ioBroker.roborock.git"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",


### PR DESCRIPTION
As you do not test node 16 any longer, this adapter shoiuld require node 18 now.

Please check PR and merge 