### PR TITLE
Update test-and-release.yml - add macos-latest

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: ioBroker/testing-action-adapter@v1


### PR DESCRIPTION
If there is no technical reason all adapters must support linux, windows and macos. And so they must be tested at all platforms.

