### PR TITLE
Add xs property to jsonConfig field

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -37,6 +37,7 @@
 			"newLine": true,
 			"min": 1,
 			"max": 240,
+			"xs": 12,
 			"sm": 12,
             "md": 6,
             "lg": 6,


### PR DESCRIPTION
Introduced the 'xs' property with a value of 12 to the relevant field in jsonConfig.json to ensure consistent layout across extra small screen sizes.