### PR TITLE
[codex] fix endpoint refresh retry after MQTT outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This feature only works when map creation is enabled in the adapter options. Ope
 ### **WORK IN PROGRESS**
 
 * (copystring) Fixed missing auto-empty command for Roborock Qrevo MaxV (#1272).
+* (copystring) Fixed local endpoint refresh after temporary MQTT outages so stale local IP recovery retries immediately again.
 * (copystring) Require bug reports to upload a `.txt` debug log file.
 
 ### 0.7.1 (2026-05-19)

--- a/src/lib/localApi.test.ts
+++ b/src/lib/localApi.test.ts
@@ -422,4 +422,35 @@ describe("local_api transport sequence", () => {
 		expect(requests).to.deep.equal([{ method: "service.get_net_info", params: {} }]);
 		expect(api.localDevices[duid].ip).to.equal("10.1.1.90");
 	});
+
+	it("does not throttle the next endpoint refresh after MQTT was temporarily unavailable", async () => {
+		const duid = "duid";
+		const adapter = new MockAdapter() as any;
+		const api = new local_api(adapter);
+		const requests: string[] = [];
+		let mqttConnected = false;
+
+		adapter.mqtt_api = { isConnected: () => mqttConnected };
+		adapter.requestsHandler = {
+			sendRequest: async (_duid: string, method: string) => {
+				requests.push(method);
+				return [{ ip: "10.1.1.91" }];
+			},
+			rejectPendingTcpRequests: () => 0,
+		};
+		adapter.getDeviceProtocolVersion = async () => "1.0";
+		api.initiateClient = async () => {};
+		api.localDevices[duid] = {
+			ip: "10.1.1.81",
+			version: "1.0",
+			staleSince: 100,
+		};
+
+		await expect(api.refreshEndpoint(duid, "mqtt down", false)).resolves.to.equal(false);
+		mqttConnected = true;
+		await expect(api.refreshEndpoint(duid, "mqtt back", false)).resolves.to.equal(true);
+
+		expect(requests).to.deep.equal(["get_network_info"]);
+		expect(api.localDevices[duid].ip).to.equal("10.1.1.91");
+	});
 });

--- a/src/lib/localApi.ts
+++ b/src/lib/localApi.ts
@@ -730,6 +730,7 @@ export class local_api {
 
 	private async refreshEndpointInternal(duid: string, reason: string): Promise<boolean> {
 		if (!this.adapter.requestsHandler?.sendRequest || !this.adapter.mqtt_api?.isConnected?.()) {
+			this.endpointRefreshLastStartedAt.delete(duid);
 			this.adapter.rLog("TCP", duid, "Debug", undefined, undefined, `Skipping endpoint refresh after ${reason}: MQTT unavailable.`, "debug");
 			return false;
 		}

--- a/src/lib/localApi.ts
+++ b/src/lib/localApi.ts
@@ -719,6 +719,12 @@ export class local_api {
 		}
 
 		const promise = this.refreshEndpointInternal(duid, reason)
+			.then((refreshed) => {
+				if (!refreshed && (!this.adapter.requestsHandler?.sendRequest || !this.adapter.mqtt_api?.isConnected?.())) {
+					this.endpointRefreshLastStartedAt.delete(duid);
+				}
+				return refreshed;
+			})
 			.finally(() => {
 				this.endpointRefreshPromises.delete(duid);
 			});
@@ -730,7 +736,6 @@ export class local_api {
 
 	private async refreshEndpointInternal(duid: string, reason: string): Promise<boolean> {
 		if (!this.adapter.requestsHandler?.sendRequest || !this.adapter.mqtt_api?.isConnected?.()) {
-			this.endpointRefreshLastStartedAt.delete(duid);
 			this.adapter.rLog("TCP", duid, "Debug", undefined, undefined, `Skipping endpoint refresh after ${reason}: MQTT unavailable.`, "debug");
 			return false;
 		}


### PR DESCRIPTION
## Summary
- clear the endpoint refresh rate-limit marker when a refresh exits early because MQTT is unavailable
- add a regression test that retries immediately once MQTT connectivity returns

## Root cause
efreshEndpoint() recorded the per-device throttle timestamp before efreshEndpointInternal() checked MQTT availability. If MQTT was temporarily unavailable, the refresh returned early but still blocked the next retry for 60 seconds.

## Validation
- repo diff review
- targeted unit test added in src/lib/localApi.test.ts
- runtime execution not performed here because 
ode_modules is absent in the Codex worktree, so local 
pm test execution was not available