### PR TITLE
fix: use compatible type import syntax

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,8 @@ import { commitInfo } from "./lib/commitInfo";
 import { AppPluginManager } from "./lib/AppPluginManager";
 import { B01Variant, getB01VariantFromModel } from "./lib/b01Variant";
 import { DeviceManager } from "./lib/deviceManager";
-import { BaseDeviceFeatures, type CommandSpec } from "./lib/features/baseDeviceFeatures";
+import { BaseDeviceFeatures } from "./lib/features/baseDeviceFeatures";
+import type { CommandSpec } from "./lib/features/baseDeviceFeatures";
 import { Feature } from "./lib/features/features.enum";
 
 import { Device, http_api } from "./lib/httpApi";


### PR DESCRIPTION
## Summary
- Split the inline named type import in src/main.ts into a normal value import plus a separate import type.
- Keeps esbuild-register used by ioBroker integration tests from failing on the inline type import syntax.

## Validation
- npm run test:integration
- npx eslint src/main.ts --max-warnings 0
- npm run typecheck
- git diff --check