### PR TITLE
Improve Dependabot automerge configuration

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,17 +1,14 @@
-# Configure here which dependency updates should be merged automatically.
-# The recommended configuration is the following:
+# Configure which Dependabot updates should be merged automatically.
+# semver:major includes minor and patch updates. The workflow still waits for CI.
 - match:
-    # Only merge patches for production dependencies
+    # Merge production dependency updates after successful checks
     dependency_type: production
-    update_type: "semver:patch"
+    update_type: "semver:major"
 - match:
-    # Except for security fixes, here we allow minor patches
-    dependency_type: production
-    update_type: "security:minor"
-- match:
-    # and development dependencies can have a minor update, too
+    # Merge development dependency updates after successful checks
     dependency_type: development
-    update_type: "semver:minor"
-
-# The syntax is based on the legacy dependabot v1 automerged_updates syntax, see:
-# https://dependabot.com/docs/config-file/#automerged_updates
+    update_type: "semver:major"
+- match:
+    # Merge lockfile-only updates after successful checks
+    dependency_type: package-lock
+    update_type: "semver:major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Dependabot runs daily at 05:00 (Europe/Berlin).
+# Dependabot runs weekly on Saturday at 03:00 (Europe/Berlin).
 # npm updates use a 7 day cooldown to reduce supply-chain risk.
 version: 2
 updates:
@@ -6,8 +6,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "05:00"
+      interval: "weekly"
+      day: "saturday"
+      time: "03:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 15
     assignees:
@@ -23,8 +24,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "05:00"
+      interval: "weekly"
+      day: "saturday"
+      time: "03:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 15
     assignees:

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -25,11 +25,8 @@ jobs:
         uses: iobroker-bot-orga/action-automerge-dependabot@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Optional: Path to your auto-merge configuration file
-          # config-file-path: '.github/auto-merge.yml'
+          config-file-path: '.github/auto-merge.yml'
           # Optional: Merge method (merge, squash, or rebase)
           # merge-method: 'squash'
-          # Optional: Wait for other checks to complete
-          # wait-for-checks: 'true'
-          # Optional: Maximum time to wait for checks in seconds (default: 3600)
-          # max-wait-time: '3600'
+          wait-for-checks: 'true'
+          max-wait-time: '3600'

--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -5,6 +5,45 @@
 * (copystring) **Fix:** Request handling – message IDs are now assigned internally (externalId removed), avoiding ID conflicts.
 * (copystring) **Maps/Rooms:** Room states are only created for segments that exist on the loaded map for that floor; room names are taken only from the API so custom names are not overwritten.
 
+### 0.7.0-beta.0 (2026-03-11)
+
+* (copystring) **Maps:** Obstacle icons and map graphics are loaded automatically at startup so maps display correctly.
+* (copystring) **Breaking Change:** Major refactoring of the entire adapter structure.
+* (copystring) **New Feature:** Implemented 'Strict Startup' - Adapter prevents startup without valid login to avoid bootloops.
+* (copystring) **Improvement:** Enhanced 2FA logging and instructions for easier login troubleshooting.
+* (copystring) **Feature:** Responsive Design for Admin UI (thanks to simatec).
+* (copystring) **New Protocol:** Added support for B01 protocol (AES-128-CBC) used by newer devices (e.g., Qrevo Slim).
+* (copystring) **Map System:** Complete overhaul of map generation using `@napi-rs/canvas`:
+    *   Improved room coloring and dark mode support.
+    *   Fixed coordinate scaling and Y-axis inversion issues.
+* (copystring) **Stability:** Fixed auto-relogin logic for invalid tokens.
+* (copystring) **Stability:** Resolved MQTT race conditions and connection instability.
+* (copystring) **Fix:** S6 MaxV Water Box & Fan Power attributes.
+* (copystring) **Fix:** Suction and mop intensity not showing (#1053).
+* (copystring) **Consumables:** Major refactoring to a data-driven, deterministic system mirroring the official Roborock app's "Maintenance" screen.
+* (copystring) **Translations:** Enhanced `TranslationManager` with case-insensitive lookups and 1:1 matching of native app labels (e.g., "Staubbeutel").
+* (copystring) **Reliability:** Added regression test suite for consumables, translations, and hour conversion logic.
+* (copystring) **Cleanup:** Removed duplicate/virtual percentage states in favor of authentic robot data.
+* (copystring) **Internal:** Modular feature handling and introduction of `lib/features/`.
+* (copystring) **Build:** Persistent caching for faster CI/CD.
+* (copystring) **Cleanup:** Removed daily build workflows.
+* (copystring) **Improved Map Retrieval:** Fixed issue where maps were not received over TCP by ignoring the initial "ok" acknowledgement and waiting for the actual map data via MQTT.
+* (copystring) **Network Probe:** Added Pre-Init Network Probe to detect local IP addresses via Cloud API before initialization, enabling faster local connection establishment (especially for Docker/VLAN setups).
+* (copystring) **UDP Discovery:** Implemented a 1.5s grace period for UDP discovery to better detect shared devices on the local network.
+* (copystring) **Bugfix:** Fixed infinite retry loop for failed Network Probes (Remote Devices).
+* (copystring) **Code Cleanup:** Removed extensive debug logging, buffering logic, and unused code for a cleaner codebase.
+* (copystring) **New devices:** Saros 20X, Q7 L5.
+* (copystring) **Fix:** Cleaning history (records) now updates correctly after a cleaning run.
+* (copystring) **Stability:** Adapter no longer gets stuck in a boot loop when login fails or returns an error.
+
+### 0.6.19 (2025-02-08)
+
+* (copystring) Rewrite of mqtt connection logic
+* (copystring) Add missing features to Qrevo Slim
+* (copystring) Start websocket & web server onReady
+* (copystring) Update LICENSE
+* (copystring) Update README.md
+
 ### 0.6.18 (2024-12-11)
  * (copystring) Add cleaned_area to S8
  * (copystring) Bugfixes for Qrevo Curve
@@ -325,61 +364,3 @@
 
 ### 0.0.2-alpha.0 (2023-01-28)
 * (copystring) initial release
-## 0.7.0-beta.0 (2026-03-11)
-* (copystring) **Maps:** Obstacle icons and map graphics are loaded automatically at startup so maps display correctly.
-* (copystring) **Breaking Change:** Major refactoring of the entire adapter structure.
-* (copystring) **New Feature:** Implemented 'Strict Startup' - Adapter prevents startup without valid login to avoid bootloops.
-* (copystring) **Improvement:** Enhanced 2FA logging and instructions for easier login troubleshooting.
-* (copystring) **Feature:** Responsive Design for Admin UI (thanks to simatec).
-* (copystring) **New Protocol:** Added support for B01 protocol (AES-128-CBC) used by newer devices (e.g., Qrevo Slim).
-* (copystring) **Map System:** Complete overhaul of map generation using `@napi-rs/canvas`:
-    *   Improved room coloring and dark mode support.
-    *   Fixed coordinate scaling and Y-axis inversion issues.
-* (copystring) **Stability:** Fixed auto-relogin logic for invalid tokens.
-* (copystring) **Stability:** Resolved MQTT race conditions and connection instability.
-* (copystring) **Fix:** S6 MaxV Water Box & Fan Power attributes.
-* (copystring) **Fix:** Suction and mop intensity not showing (#1053).
-* (copystring) **Consumables:** Major refactoring to a data-driven, deterministic system mirroring the official Roborock app's "Maintenance" screen.
-* (copystring) **Translations:** Enhanced `TranslationManager` with case-insensitive lookups and 1:1 matching of native app labels (e.g., "Staubbeutel").
-* (copystring) **Reliability:** Added regression test suite for consumables, translations, and hour conversion logic.
-* (copystring) **Cleanup:** Removed duplicate/virtual percentage states in favor of authentic robot data.
-* (copystring) **Internal:** Modular feature handling and introduction of `lib/features/`.
-* (copystring) **Build:** Persistent caching for faster CI/CD.
-* (copystring) **Cleanup:** Removed daily build workflows.
-* (copystring) **Improved Map Retrieval:** Fixed issue where maps were not received over TCP by ignoring the initial "ok" acknowledgement and waiting for the actual map data via MQTT.
-* (copystring) **Network Probe:** Added Pre-Init Network Probe to detect local IP addresses via Cloud API before initialization, enabling faster local connection establishment (especially for Docker/VLAN setups).
-* (copystring) **UDP Discovery:** Implemented a 1.5s grace period for UDP discovery to better detect shared devices on the local network.
-* (copystring) **Bugfix:** Fixed infinite retry loop for failed Network Probes (Remote Devices).
-* (copystring) **Code Cleanup:** Removed extensive debug logging, buffering logic, and unused code for a cleaner codebase.
-* (copystring) **New devices:** Saros 20X, Q7 L5.
-* (copystring) **Fix:** Cleaning history (records) now updates correctly after a cleaning run.
-* (copystring) **Stability:** Adapter no longer gets stuck in a boot loop when login fails or returns an error.
-
-Older changes can be found in [CHANGELOG_OLD.md](CHANGELOG_OLD.md).## License
-MIT License
-
-Copyright (c) 2025-2026 copystring <copystring@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-
-## 0.6.19 (2025-02-08)
-* (copystring) Rewrite of mqtt connection logic
-* (copystring) Add missing features to Qrevo Slim
-* (copystring) Start websocket & web server onReady
-* (copystring) Update LICENSE
-* (copystring) Update README.md

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ This feature only works when map creation is enabled in the adapter options. Ope
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (copystring) Fixed consumable percentage values for devices where Roborock reports maintenance data via HomeData.
+* (copystring) Re-enabled macOS support and added macOS test coverage.
+* (copystring) Improved dependency update automation so updates are checked weekly and merged only after successful checks.
+
 ### 0.7.3 (2026-05-22)
 
 * (copystring) Fixed V1 auto-empty dust collection to use the AppPlugin-verified `app_start_collect_dust` command.


### PR DESCRIPTION
Updates Dependabot automerge rules, switches dependency checks to weekly Saturday runs, and adds a readable README changelog entry for the changes since 0.7.3. Also fixes the misplaced old changelog entries that were mixed with license text in CHANGELOG_OLD.md. Validation: npm run lint:yaml passed; git diff --check passed. The local ioBroker repochecker could not complete because GitHub API returned 403 before repository checks ran.