### PR TITLE
Avoid duplicate CI build checks

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -69,6 +69,7 @@ jobs:
           os: ${{ matrix.os }}
           package-cache: 'npm'
           build: true
+          build-command: 'npm run clean && npm run build:www && npm run docs'
 
   # Deploys the final package to NPM
   deploy:


### PR DESCRIPTION
Keeps the adapter test matrix intact, but avoids repeating lint and typecheck inside every matrix build. The dedicated check-and-lint job still runs lint, package checks and TypeScript checking. Adapter test jobs still build the web/docs artifacts and run unit and integration tests on every OS and Node version. Validation: npm run lint:yaml passed; git diff --check passed.