### PR TITLE
Test CI without ioBroker temp cache

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -51,18 +51,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Cache ioBroker Controller / Temp
-        uses: actions/cache@v5
-        with:
-          path: |
-            C:\Users\runneradmin\AppData\Local\Temp\test-iobroker.roborock
-            /tmp/test-iobroker.roborock
-          key: iobroker-controller-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            iobroker-controller-${{ runner.os }}-${{ matrix.node-version }}-
-
       - uses: ioBroker/testing-action-adapter@v1
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Experiment to measure whether the explicit ioBroker temp/controller cache is still a net win. This does not remove adapter tests; ioBroker/testing-action-adapter still checks out the code, installs dependencies, builds, runs unit tests and runs integration tests. If this is slower, this PR should be closed instead of merged. Validation before pushing: npm run lint:yaml passed; git diff --check passed.