### PR TITLE
Reduce adapter CI checkout overhead and update changelog

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -51,17 +51,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
-
       - name: Cache ioBroker Controller / Temp
         uses: actions/cache@v5
         with:
           path: |
             C:\Users\runneradmin\AppData\Local\Temp\test-iobroker.roborock
             /tmp/test-iobroker.roborock
-          key: iobroker-controller-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            iobroker-controller-${{ runner.os }}-${{ matrix.node-version }}-
+          key: iobroker-controller-${{ runner.os }}-${{ matrix.node-version }}
 
       - uses: ioBroker/testing-action-adapter@v1
         with:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This feature only works when map creation is enabled in the adapter options. Ope
 * (copystring) Fixed consumable percentage values for devices where Roborock reports maintenance data via HomeData.
 * (copystring) Re-enabled macOS support and added macOS test coverage.
 * (copystring) Improved dependency update automation so updates are checked weekly and merged only after successful checks.
+* (copystring) Updated `p-queue` to 9.3.0 and `protobufjs` to 8.5.0.
+* (copystring) Improved CI performance for Linux, macOS and Windows adapter tests without reducing test coverage.
 
 ### 0.7.3 (2026-05-22)
 


### PR DESCRIPTION
## Summary
- remove the outer adapter-test checkout before the ioBroker temp cache
- keep the ioBroker controller/temp cache enabled
- use an OS/Node scoped controller cache key instead of tying it to the adapter package lock
- update the WORK IN PROGRESS changelog for recent dependency and CI improvements

## Why
The adapter test action already checks out the repository. The extra checkout was only needed for hashFiles(package-lock.json), but the cached ioBroker controller temp directory is independent from the adapter lockfile.

## Validation
- npm run lint:yaml
- git diff --check
- GitHub PR checks