### PR TITLE
Fix Qrevo Edge 2 water mode mapping

### DIFF
--- a/src/lib/features/vacuum/a187_features.ts
+++ b/src/lib/features/vacuum/a187_features.ts
@@ -1,40 +1,7 @@
-import { V1VacuumFeatures, VacuumProfile, BASE_FAN, BASE_MOP } from "./v1VacuumFeatures";
+﻿import { V1VacuumFeatures, VacuumProfile, BASE_FAN, BASE_WATER, BASE_MOP } from "./v1VacuumFeatures";
 import { RegisterModel, DeviceModelConfig, FeatureDependencies } from "../baseDeviceFeatures";
 import { Feature } from "../features.enum";
 
-const QREVO_EDGE_WATER = {
-	200: "Off",
-	221: "Very Light",
-	222: "Very Light",
-	223: "Very Light",
-	224: "Low",
-	225: "Low",
-	226: "Low",
-	227: "Low",
-	228: "Gentle",
-	229: "Gentle",
-	230: "Gentle",
-	231: "Gentle",
-	232: "Gentle",
-	233: "Medium",
-	234: "Medium",
-	235: "Medium",
-	236: "Medium",
-	237: "Medium",
-	238: "Moderate",
-	239: "Moderate",
-	240: "Moderate",
-	241: "Moderate",
-	242: "Moderate",
-	243: "High",
-	244: "High",
-	245: "High",
-	246: "High",
-	247: "High",
-	248: "Extreme",
-	249: "Extreme",
-	250: "Extreme"
-};
 const PROFILE_A187: VacuumProfile = {
 	name: "Roborock Qrevo Edge Series (a187)",
 	features: {
@@ -43,7 +10,7 @@ const PROFILE_A187: VacuumProfile = {
 	},
 	mappings: {
 		fan_power: { ...BASE_FAN, 108: "Max+" },
-		water_box_mode: QREVO_EDGE_WATER,
+		water_box_mode: BASE_WATER,
 		mop_mode: BASE_MOP
 	}
 };

--- a/src/lib/features/vacuum/a187_features.ts
+++ b/src/lib/features/vacuum/a187_features.ts
@@ -1,7 +1,40 @@
-﻿import { V1VacuumFeatures, VacuumProfile, BASE_FAN, BASE_WATER, BASE_MOP } from "./v1VacuumFeatures";
+import { V1VacuumFeatures, VacuumProfile, BASE_FAN, BASE_MOP } from "./v1VacuumFeatures";
 import { RegisterModel, DeviceModelConfig, FeatureDependencies } from "../baseDeviceFeatures";
 import { Feature } from "../features.enum";
 
+const QREVO_EDGE_WATER = {
+	200: "Off",
+	221: "Very Light",
+	222: "Very Light",
+	223: "Very Light",
+	224: "Low",
+	225: "Low",
+	226: "Low",
+	227: "Low",
+	228: "Gentle",
+	229: "Gentle",
+	230: "Gentle",
+	231: "Gentle",
+	232: "Gentle",
+	233: "Medium",
+	234: "Medium",
+	235: "Medium",
+	236: "Medium",
+	237: "Medium",
+	238: "Moderate",
+	239: "Moderate",
+	240: "Moderate",
+	241: "Moderate",
+	242: "Moderate",
+	243: "High",
+	244: "High",
+	245: "High",
+	246: "High",
+	247: "High",
+	248: "Extreme",
+	249: "Extreme",
+	250: "Extreme"
+};
 const PROFILE_A187: VacuumProfile = {
 	name: "Roborock Qrevo Edge Series (a187)",
 	features: {
@@ -10,7 +43,7 @@ const PROFILE_A187: VacuumProfile = {
 	},
 	mappings: {
 		fan_power: { ...BASE_FAN, 108: "Max+" },
-		water_box_mode: BASE_WATER,
+		water_box_mode: QREVO_EDGE_WATER,
 		mop_mode: BASE_MOP
 	}
 };

--- a/src/lib/features/vacuum/a298_features.ts
+++ b/src/lib/features/vacuum/a298_features.ts
@@ -1,0 +1,83 @@
+import { V1VacuumFeatures, VacuumProfile, BASE_FAN, BASE_MOP } from "./v1VacuumFeatures";
+import { RegisterModel, DeviceModelConfig, FeatureDependencies } from "../baseDeviceFeatures";
+import { Feature } from "../features.enum";
+
+const QREVO_EDGE_2_WATER = {
+	200: "Off",
+	221: "Very Light",
+	222: "Very Light",
+	223: "Very Light",
+	224: "Low",
+	225: "Low",
+	226: "Low",
+	227: "Low",
+	228: "Gentle",
+	229: "Gentle",
+	230: "Gentle",
+	231: "Gentle",
+	232: "Gentle",
+	233: "Medium",
+	234: "Medium",
+	235: "Medium",
+	236: "Medium",
+	237: "Medium",
+	238: "Moderate",
+	239: "Moderate",
+	240: "Moderate",
+	241: "Moderate",
+	242: "Moderate",
+	243: "High",
+	244: "High",
+	245: "High",
+	246: "High",
+	247: "High",
+	248: "Extreme",
+	249: "Extreme",
+	250: "Extreme"
+};
+
+const PROFILE_A298: VacuumProfile = {
+	name: "Roborock Qrevo Edge 2 (a298)",
+	features: {
+		maxSuctionValue: 108,
+		hasSmartPlan: true
+	},
+	mappings: {
+		fan_power: { ...BASE_FAN, 108: "Max+" },
+		water_box_mode: QREVO_EDGE_2_WATER,
+		mop_mode: BASE_MOP
+	}
+};
+
+const a298Config: DeviceModelConfig = {
+	staticFeatures: [
+		Feature.FanMaxPlus,
+		Feature.SmartModeCommand,
+		Feature.WaterBox,
+		Feature.CommonStatus,
+		Feature.DockStatus,
+		Feature.RobotStatus,
+		Feature.CleanPercent,
+		Feature.ChargeStatus,
+		Feature.InWarmup,
+		Feature.MapFlag,
+		Feature.TaskId,
+		Feature.LastCleanTime,
+		Feature.SwitchStatus,
+		Feature.CleaningInfo,
+		Feature.AutoEmptyDock,
+		Feature.MopWash,
+		Feature.MopDry,
+		Feature.CleanRepeat,
+		Feature.CleanedArea,
+		Feature.MopForbidden,
+		Feature.AvoidCarpet
+	]
+};
+
+@RegisterModel("roborock.vacuum.a298")
+export class A298Features extends V1VacuumFeatures {
+	constructor(dependencies: FeatureDependencies, duid: string) {
+		super(dependencies, duid, "roborock.vacuum.a298", a298Config, PROFILE_A298);
+	}
+}

--- a/src/lib/features/vacuum/index.ts
+++ b/src/lib/features/vacuum/index.ts
@@ -19,6 +19,7 @@ export * from "./a19_features";
 export * from "./a21_features";
 export * from "./a27_features";
 export * from "./a288_features";
+export * from "./a298_features";
 export * from "./a38_features";
 export * from "./a40_features";
 export * from "./a51_features";

--- a/src/lib/features/vacuum/qrevo_edge_water_mapping.test.ts
+++ b/src/lib/features/vacuum/qrevo_edge_water_mapping.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { FeatureDependencies } from "../baseDeviceFeatures";
+import { A187Features } from "./a187_features";
+
+function createDeps(): FeatureDependencies {
+	const adapter: any = {
+		namespace: "roborock.0",
+		log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() },
+		translations: {},
+		rLog: vi.fn(),
+		setStateChanged: vi.fn().mockResolvedValue(undefined),
+		extendObject: vi.fn().mockResolvedValue(undefined),
+		getDeviceProtocolVersion: vi.fn().mockResolvedValue("1.0"),
+		http_api: {
+			getDevices: vi.fn().mockReturnValue([]),
+			getFwFeaturesResult: vi.fn(),
+			storeFwFeaturesResult: vi.fn()
+		},
+		requestsHandler: { sendRequest: vi.fn().mockResolvedValue({}) },
+		translationManager: { get: vi.fn().mockImplementation((key, def) => def || key) }
+	};
+
+	return {
+		adapter,
+		http_api: adapter.http_api,
+		ensureState: vi.fn().mockResolvedValue(undefined),
+		ensureFolder: vi.fn().mockResolvedValue(undefined),
+		log: adapter.log,
+		config: { staticFeatures: [] }
+	} as unknown as FeatureDependencies;
+}
+
+describe("Qrevo Edge 2 water mapping", () => {
+	it("uses the Edge 2 custom water range for a187", async () => {
+		const vacuum = new A187Features(createDeps(), "duid1") as any;
+
+		await vacuum.setupProtocolFeatures();
+
+		expect(vacuum.commands.set_water_box_custom_mode.states).toMatchObject({
+			200: "Off",
+			221: "Very Light",
+			235: "Medium",
+			250: "Extreme"
+		});
+		expect(Object.keys(vacuum.commands.set_water_box_custom_mode.states).map(Number)).toEqual([
+			200,
+			221,
+			222,
+			223,
+			224,
+			225,
+			226,
+			227,
+			228,
+			229,
+			230,
+			231,
+			232,
+			233,
+			234,
+			235,
+			236,
+			237,
+			238,
+			239,
+			240,
+			241,
+			242,
+			243,
+			244,
+			245,
+			246,
+			247,
+			248,
+			249,
+			250
+		]);
+	});
+});

--- a/src/lib/features/vacuum/qrevo_edge_water_mapping.test.ts
+++ b/src/lib/features/vacuum/qrevo_edge_water_mapping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { FeatureDependencies } from "../baseDeviceFeatures";
-import { A187Features } from "./a187_features";
+import { A298Features } from "./a298_features";
 
 function createDeps(): FeatureDependencies {
 	const adapter: any = {
@@ -31,8 +31,8 @@ function createDeps(): FeatureDependencies {
 }
 
 describe("Qrevo Edge 2 water mapping", () => {
-	it("uses the Edge 2 custom water range for a187", async () => {
-		const vacuum = new A187Features(createDeps(), "duid1") as any;
+	it("uses the Edge 2 custom water range for a298", async () => {
+		const vacuum = new A298Features(createDeps(), "duid1") as any;
 
 		await vacuum.setupProtocolFeatures();
 


### PR DESCRIPTION
Fixes #1355.

Summary:
- adds a dedicated roborock.vacuum.a298 profile for Qrevo Edge 2
- uses the confirmed water_box_mode mapping 200 and 221..250 for set_water_box_custom_mode
- reverts the earlier unverified a187 mapping change back to the standard water mapping
- adds a focused regression test for the a298 water mapping

Validation:
- npm run typecheck
- npx eslint src/lib/features/vacuum/a187_features.ts src/lib/features/vacuum/a298_features.ts src/lib/features/vacuum/index.ts src/lib/features/vacuum/qrevo_edge_water_mapping.test.ts --max-warnings 0 --no-warn-ignored
- npx vitest run --coverage.enabled=false --testTimeout=10000

The reporter confirmed the branch works after the fix was moved to roborock.vacuum.a298.
