### PR TITLE
fix: handle B01 local endpoint probing

### DIFF
--- a/src/lib/localApi.test.ts
+++ b/src/lib/localApi.test.ts
@@ -423,6 +423,33 @@ describe("local_api transport sequence", () => {
 		expect(api.localDevices[duid].ip).to.equal("10.1.1.90");
 	});
 
+	it("promotes a B01 endpoint during pre-init probing with the B01 network info method", async () => {
+		const duid = "duid";
+		const adapter = new MockAdapter() as any;
+		const api = new local_api(adapter);
+		const requests: Array<{ method: string; params: unknown; timeout: number | undefined }> = [];
+		const promotions: Array<{ ip: string; timeoutMs: number | undefined; suppressLog: boolean | undefined }> = [];
+
+		adapter.mqtt_api = { isConnected: () => true };
+		adapter.requestsHandler = {
+			sendRequest: async (_duid: string, method: string, params: unknown, options: { timeout?: number }) => {
+				requests.push({ method, params, timeout: options.timeout });
+				return { ip: "10.1.1.90" };
+			},
+			rejectPendingTcpRequests: () => 0,
+		};
+		adapter.getDeviceProtocolVersion = async () => "B01";
+		api.checkAndPromoteLocalConnection = async (_duid: string, ip: string, timeoutMs?: number, suppressLog?: boolean) => {
+			promotions.push({ ip, timeoutMs, suppressLog });
+			return true;
+		};
+
+		await expect(api.probeLocalEndpointFromNetworkInfo(duid, "test", 1500, true, 3000)).resolves.to.equal(true);
+
+		expect(requests).to.deep.equal([{ method: "service.get_net_info", params: {}, timeout: 3000 }]);
+		expect(promotions).to.deep.equal([{ ip: "10.1.1.90", timeoutMs: 1500, suppressLog: true }]);
+	});
+
 	it("does not throttle the next endpoint refresh after MQTT was temporarily unavailable", async () => {
 		const duid = "duid";
 		const adapter = new MockAdapter() as any;

--- a/src/lib/localApi.ts
+++ b/src/lib/localApi.ts
@@ -781,10 +781,10 @@ export class local_api {
 		return promise;
 	}
 
-	private async refreshEndpointInternal(duid: string, reason: string): Promise<boolean> {
+	private async fetchNetworkInfoEndpoint(duid: string, reason: string, timeoutMs = 5000): Promise<{ ip: string; version: string; method: string } | null> {
 		if (!this.adapter.requestsHandler?.sendRequest || !this.adapter.mqtt_api?.isConnected?.()) {
 			this.adapter.rLog("TCP", duid, "Debug", undefined, undefined, `Skipping endpoint refresh after ${reason}: MQTT unavailable.`, "debug");
-			return false;
+			return null;
 		}
 
 		const version = await this.adapter.getDeviceProtocolVersion(duid);
@@ -793,21 +793,39 @@ export class local_api {
 
 		let result: unknown;
 		try {
-			result = await this.adapter.requestsHandler.sendRequest(duid, method, params, { priority: -10, timeout: 5000 });
+			result = await this.adapter.requestsHandler.sendRequest(duid, method, params, { priority: -10, timeout: timeoutMs });
 		} catch (e: unknown) {
 			this.adapter.rLog("TCP", duid, "Debug", version, undefined, `Endpoint refresh ${method} failed after ${reason}: ${this.adapter.errorMessage(e)}`, "debug");
-			return false;
+			return null;
 		}
 
 		const ip = this.extractIpFromNetworkInfo(result);
 		if (!ip) {
 			this.adapter.rLog("TCP", duid, "Debug", version, undefined, `Endpoint refresh ${method} returned no usable IP.`, "debug");
+			return null;
+		}
+
+		return { ip, version, method };
+	}
+
+	private async refreshEndpointInternal(duid: string, reason: string): Promise<boolean> {
+		const endpoint = await this.fetchNetworkInfoEndpoint(duid, reason);
+		if (!endpoint) {
 			return false;
 		}
 
-		const changed = this.updateLocalEndpoint(duid, ip, version, "network_info");
-		this.adapter.rLog("TCP", duid, "Debug", version, undefined, `Endpoint refresh resolved ${ip}${changed ? " (updated)" : ""}.`, "debug");
+		const changed = this.updateLocalEndpoint(duid, endpoint.ip, endpoint.version, "network_info");
+		this.adapter.rLog("TCP", duid, "Debug", endpoint.version, undefined, `Endpoint refresh resolved ${endpoint.ip}${changed ? " (updated)" : ""}.`, "debug");
 		return true;
+	}
+
+	public async probeLocalEndpointFromNetworkInfo(duid: string, reason = "endpoint probe", tcpTimeoutMs = 5000, suppressLog = false, networkInfoTimeoutMs = 5000): Promise<boolean> {
+		const endpoint = await this.fetchNetworkInfoEndpoint(duid, reason, networkInfoTimeoutMs);
+		if (!endpoint) {
+			return false;
+		}
+
+		return this.checkAndPromoteLocalConnection(duid, endpoint.ip, tcpTimeoutMs, suppressLog);
 	}
 
 	public async refreshStaleLocalEndpoints(reason = "scheduled endpoint refresh"): Promise<void> {

--- a/src/lib/mqttApi.ts
+++ b/src/lib/mqttApi.ts
@@ -427,6 +427,12 @@ export class mqtt_api {
 		try {
 			const payloadStr = Buffer.isBuffer(data.payload) ? data.payload.toString("utf8") : String(data.payload ?? "");
 			const parsed = JSON.parse(payloadStr);
+
+			if (data.version === "B01" && parsed.dps?.["10001"]) {
+				await this.dispatchB01Message(duid, parsed);
+				return;
+			}
+
 			let dps102 = parsed.dps?.["102"] || (parsed.dps ? parsed.dps : null);
 			const b01Variant = await this.adapter.getB01Variant(duid);
 			const handler = this.adapter.deviceFeatureHandlers.get(duid);

--- a/src/main.ts
+++ b/src/main.ts
@@ -259,20 +259,9 @@ export class Roborock extends utils.Adapter {
 				}
 
 				try {
-					// 1. Get Network Info (via MQTT as we have no TCP yet)
-					const result = await this.requestsHandler.sendRequest(duid, "get_network_info", []);
-
-					// 2. Extract IP
-					let networkData: Record<string, unknown> | undefined;
-					if (Array.isArray(result)) {
-						networkData = result[0] as Record<string, unknown>;
-					} else if (result && typeof result === "object") {
-						networkData = result as Record<string, unknown>;
-					}
-
-					if (networkData && typeof networkData.ip === "string") {
-						// 3. Attempt TCP Connect with short timeout (1.5s) and silent logging
-						await this.local_api.checkAndPromoteLocalConnection(duid, networkData.ip, 1500, true);
+					const promoted = await this.local_api.probeLocalEndpointFromNetworkInfo(duid, "pre-init network probe", 1500, true, 3000);
+					if (!promoted) {
+						this.rLog("System", duid, "Debug", undefined, undefined, "Probe did not resolve a local TCP endpoint.", "debug");
 					}
 				} catch (e: unknown) {
 					const errorMsg = e instanceof Error ? e.message : String(e);
@@ -283,7 +272,7 @@ export class Roborock extends utils.Adapter {
 			// Wait for all probes to finish (with timeout to not block forever)
 			await Promise.race([
 				Promise.all(probePromises),
-				this.delay(2000) // Max 2s probe time
+				this.delay(4000) // Max 4s probe time
 			]);
 			this.rLog("System", null, "Info", undefined, undefined, "Network Probe finished.", "info");
 			// ----------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -259,7 +259,7 @@ export class Roborock extends utils.Adapter {
 				}
 
 				try {
-					const promoted = await this.local_api.probeLocalEndpointFromNetworkInfo(duid, "pre-init network probe", 1500, true, 3000);
+					const promoted = await this.local_api.probeLocalEndpointFromNetworkInfo(duid, "pre-init network probe", 1500, true, 10000);
 					if (!promoted) {
 						this.rLog("System", duid, "Debug", undefined, undefined, "Probe did not resolve a local TCP endpoint.", "debug");
 					}
@@ -272,7 +272,7 @@ export class Roborock extends utils.Adapter {
 			// Wait for all probes to finish (with timeout to not block forever)
 			await Promise.race([
 				Promise.all(probePromises),
-				this.delay(4000) // Max 4s probe time
+				this.delay(10000) // Max 10s probe time
 			]);
 			this.rLog("System", null, "Info", undefined, undefined, "Network Probe finished.", "info");
 			// ----------------------------------------------------

--- a/test/unit/q10_b01_map.test.ts
+++ b/test/unit/q10_b01_map.test.ts
@@ -1072,6 +1072,52 @@ describe("Q10 B01 Map Support", () => {
 		expect(raw102Logs).toHaveLength(1);
 	});
 
+	it("should resolve B01 command responses wrapped in protocol 102 dps 10001", async () => {
+		const adapter = new MockAdapter() as MockAdapter & {
+			deviceFeatureHandlers: Map<string, unknown>;
+			pendingRequests: Map<number, unknown>;
+			requestsHandler: {
+				resolvePendingRequest: ReturnType<typeof vi.fn>;
+				isRequestRecentlyFinished: ReturnType<typeof vi.fn>;
+			};
+			rLog: ReturnType<typeof vi.fn>;
+		};
+		adapter.deviceFeatureHandlers = new Map([[Q10_DUID, {}]]);
+		adapter.pendingRequests = new Map([[1782631354171, { method: "prop.get", duid: Q10_DUID }]]);
+		adapter.requestsHandler = {
+			resolvePendingRequest: vi.fn(),
+			isRequestRecentlyFinished: vi.fn().mockReturnValue(false)
+		} as any;
+		adapter.rLog = vi.fn();
+
+		const mqttApi = new mqtt_api(adapter as any);
+		const rawPayload = JSON.stringify({
+			dps: {
+				"10001": JSON.stringify({
+					msgId: "1782631354171",
+					code: 1,
+					method: "prop.get",
+					data: { status: 4, quantity: 100 }
+				})
+			}
+		});
+
+		await (mqttApi as any).handleProtocol102(Q10_DUID, {
+			version: "B01",
+			protocol: 102,
+			payload: Buffer.from(rawPayload, "utf8")
+		});
+
+		expect(adapter.requestsHandler.resolvePendingRequest).toHaveBeenCalledWith(
+			1782631354171,
+			{ status: 4, quantity: 100 },
+			"MQTT-B01",
+			Q10_DUID,
+			"MQTT"
+		);
+		expect(adapter.rLog).not.toHaveBeenCalledWith("MQTT", Q10_DUID, "<-", "B01", "102", rawPayload, "debug");
+	});
+
 	it("should suppress raw logs for recognized unsolicited Q10 protocol 102 payloads", async () => {
 		const adapter = new MockAdapter() as MockAdapter & {
 			deviceFeatureHandlers: Map<string, unknown>;


### PR DESCRIPTION
## Summary
- fix B01 protocol 102 command responses wrapped in `dps.10001` so matching requests resolve instead of timing out
- reuse the protocol-aware network-info endpoint path for startup local probing
- allow the B01 startup probe enough time to avoid false transient warnings

## Validation
- `npm run typecheck`
- `npx vitest run src/lib/localApi.test.ts test/unit/q10_b01_map.test.ts`

Fixes #1339
