### PR TITLE
Fix docking station status detection without dss

### DIFF
--- a/src/lib/features/vacuum/v1VacuumFeatures.test.ts
+++ b/src/lib/features/vacuum/v1VacuumFeatures.test.ts
@@ -66,10 +66,21 @@ describe("V1VacuumFeatures", () => {
 		protected getDynamicFeatures(): Set<Feature> {
 			return new Set();
 		}
-		public async detectAndApplyRuntimeFeatures(): Promise<boolean> {
-			return false;
-		}
 	}
+
+	it("should initialize docking station states when status reports a dock without dss", async () => {
+		const vacuum = new TestVacuum(depsMock, "duid1", "roborock.vacuum.a62", { staticFeatures: [] });
+
+		const changed = await vacuum.detectAndApplyRuntimeFeatures({ dock_type: 3 });
+
+		expect(changed).toBe(true);
+		expect(depsMock.ensureFolder).toHaveBeenCalledWith("Devices.duid1.dockingStationStatus");
+		expect(depsMock.ensureState).toHaveBeenCalledTimes(6);
+		expect(depsMock.ensureState).toHaveBeenCalledWith(
+			"Devices.duid1.dockingStationStatus.dustBagStatus",
+			expect.objectContaining({ read: true, write: false })
+		);
+	});
 
 	it("should parse dss bitmask correctly in updateDockingStationStatus", async () => {
 		const vacuum = new TestVacuum(depsMock, "duid1", "roborock.vacuum.a70", { staticFeatures: [Feature.DockingStationStatus] });

--- a/src/lib/features/vacuum/v1VacuumFeatures.ts
+++ b/src/lib/features/vacuum/v1VacuumFeatures.ts
@@ -188,9 +188,12 @@ export class V1VacuumFeatures extends BaseDeviceFeatures {
 		// Consumables detection (usually static, but can check for keys)
 		if (await this.applyFeature(Feature.Consumables)) changed = true;
 
+		const dockType = Number(statusData["dock_type"]);
+		const hasDock = (Number.isFinite(dockType) && dockType > 0) || statusData["dss"] !== undefined;
+		if (hasDock && await this.applyFeature(Feature.DockingStationStatus)) changed = true;
+
 		if (statusData["dss"] !== undefined) {
 			const dss = Number(statusData["dss"]);
-			// DockingStationStatus: no applyFeature – folder/states created lazily in updateDockingStationStatus()
 
 			// Bits 6-7: Dust bag status (0=not supported/missing)
 			if (((dss >> 6) & 0b11) > 0) {


### PR DESCRIPTION
Fixes #1359

## Ursache

Die gemeinsame V1-Laufzeiterkennung hat `dockingStationStatus` nur angelegt, wenn `get_status` ein `dss`-Feld enthielt. Der S7 Pro Ultra aus dem Issue meldet seine Ultra-Station mit `dock_type: 3`, lässt `dss` mit dem aktuellen Firmwarestand aber weg. Dadurch wurde das komplette Objektschema nicht erstellt.

## Änderung

- Eine gemeldete Dockingstation (`dock_type > 0`) aktiviert zentral `DockingStationStatus`.
- Geräte, die `dss` liefern, bleiben unverändert unterstützt.
- Ein Regressionstest bildet den gemeldeten S7-Pro-Ultra-Fall `dock_type: 3` ohne `dss` ab.

## Auswirkung

Das Verzeichnis `Devices.<duid>.dockingStationStatus` und seine sechs Statusobjekte werden für erkannte Dockingstationen zuverlässig angelegt. Statuswerte aus dem `dss`-Bitfeld werden weiterhin nur geschrieben, wenn das Gerät dieses Feld tatsächlich liefert.

## Prüfung

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit` — 42 Testdateien, 270 Tests bestanden
- `git diff --check`
