### PR TITLE
Map localized S7 dock error states

### DIFF
--- a/lib/protocols/roborock_error_codes.json
+++ b/lib/protocols/roborock_error_codes.json
@@ -1,0 +1,2155 @@
+{
+  "_meta": {
+    "description": "Roborock AppPlugin error definitions. Translation keys resolve through roborock_strings.json.",
+    "pluginFilter": "s7 maxv",
+    "sources": [
+      "S7 MaxV/8328da4abbd14f0f99d6c32e17af5a8b/index.android.bundle",
+      "S7 MaxV/8328da4abbd14f0f99d6c32e17af5a8b/metro_bundle_split/modules/module_1639.js",
+      "S7 MaxV/extracted/index.android.bundle",
+      "S7 MaxV/extracted/metro_bundle_split/modules/module_1639.js"
+    ]
+  },
+  "codes": {
+    "0": {
+      "types": [
+        "OK"
+      ],
+      "titleKeys": [],
+      "subtitleKeys": [],
+      "descriptionKeys": [],
+      "detailKeys": [],
+      "labelKeys": [],
+      "fallback": "No error"
+    },
+    "1": {
+      "types": [
+        "Laser"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_0"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_1"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_2"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_0"
+      ],
+      "fallback": "LiDAR Sensor error"
+    },
+    "2": {
+      "types": [
+        "Bumper"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_3"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_4"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_5"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_3"
+      ],
+      "fallback": "Bumper stuck"
+    },
+    "3": {
+      "types": [
+        "Drop"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_6"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_7"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_7"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_6"
+      ],
+      "fallback": "Wheels suspended"
+    },
+    "4": {
+      "types": [
+        "Cliff"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_9"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_10"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_11"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_9"
+      ],
+      "fallback": "Cliff sensor error"
+    },
+    "5": {
+      "types": [
+        "MainStall"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_12"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_13"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_14"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_12"
+      ],
+      "fallback": "Main brush jammed."
+    },
+    "6": {
+      "types": [
+        "SideStall",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_15"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_16"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_17",
+        "localization_strings_Main_Constants_16"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_15"
+      ],
+      "fallback": "Side brush jammed."
+    },
+    "7": {
+      "types": [
+        "Wheel"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_18"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_19"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_20"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_18"
+      ],
+      "fallback": "The robot is stuck, or main wheels are jammed."
+    },
+    "8": {
+      "types": [
+        "Stuck"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_21"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_22"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_23"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_21"
+      ],
+      "fallback": "The robot is trapped or stuck."
+    },
+    "9": {
+      "types": [
+        "Dustbin"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_24"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_25"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_26"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_24"
+      ],
+      "fallback": "Dustbin not installed"
+    },
+    "10": {
+      "types": [
+        "Strainer",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_27",
+        "localization_strings_Main_Constants_91"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_28"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_29",
+        "localization_strings_Main_Constants_92"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_91",
+        "localization_strings_Main_Constants_27"
+      ],
+      "fallback": "Filter is blocked."
+    },
+    "11": {
+      "types": [
+        "Compass"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_30"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_7"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_32"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_30"
+      ],
+      "fallback": "Strong magnetic field detected."
+    },
+    "12": {
+      "types": [
+        "Power"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_33"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_34"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_34"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_33"
+      ],
+      "fallback": "Low battery"
+    },
+    "13": {
+      "types": [
+        "Charge"
+      ],
+      "titleKeys": [
+        "localization_strings_Common_Constants_10"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_37"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_38"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Common_Constants_10"
+      ],
+      "fallback": "Charging Error"
+    },
+    "14": {
+      "types": [
+        "Battery"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_39"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_40"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_41"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_39"
+      ],
+      "fallback": "Unit temperature protection"
+    },
+    "15": {
+      "types": [
+        "WallSensor"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_42"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_43"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_44"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_42"
+      ],
+      "fallback": "The wall sensor is dirty."
+    },
+    "16": {
+      "types": [
+        "Acc"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_45"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_46"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_47"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_45"
+      ],
+      "fallback": "Robot is tilted"
+    },
+    "17": {
+      "types": [
+        "SideBrush",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_48"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_50",
+        "localization_strings_Main_Constants_49"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_48"
+      ],
+      "fallback": "Side brush error"
+    },
+    "18": {
+      "types": [
+        "Fan"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_51"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_53"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_51"
+      ],
+      "fallback": "Fan error"
+    },
+    "19": {
+      "types": [
+        "Dock"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_54"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_55"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_56"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_54"
+      ],
+      "fallback": "Dock not connected to power"
+    },
+    "21": {
+      "types": [
+        "Lds"
+      ],
+      "titleKeys": [
+        "rubys_error_21_title"
+      ],
+      "subtitleKeys": [
+        "rubys_error_21_subtitle"
+      ],
+      "descriptionKeys": [
+        "rubys_error_21_description"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "rubys_error_21_title"
+      ],
+      "fallback": "Vertical Bumper Error"
+    },
+    "22": {
+      "types": [
+        "BackSensor"
+      ],
+      "titleKeys": [
+        "rubys_error_22_title"
+      ],
+      "subtitleKeys": [
+        "rubys_error_22_subtitle"
+      ],
+      "descriptionKeys": [
+        "rubys_error_22_description"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "rubys_error_22_title"
+      ],
+      "fallback": "Recharge Sensor Error"
+    },
+    "23": {
+      "types": [
+        "DockSensor"
+      ],
+      "titleKeys": [
+        "rubys_error_23_title"
+      ],
+      "subtitleKeys": [
+        "rubys_error_23_subtitle"
+      ],
+      "descriptionKeys": [
+        "rubys_error_23_description"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "rubys_error_23_title"
+      ],
+      "fallback": "Could not Reach Dock"
+    },
+    "24": {
+      "types": [
+        "Forbidden"
+      ],
+      "titleKeys": [
+        "error_robot_in_forbidden"
+      ],
+      "subtitleKeys": [
+        "please_take_robot_out_of_forbidden"
+      ],
+      "descriptionKeys": [
+        "map_edit_robot_in_forbidden"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_robot_in_forbidden"
+      ],
+      "fallback": "No-Go Zone or Invisible Wall detected"
+    },
+    "25": {
+      "types": [
+        "VisualSensor"
+      ],
+      "titleKeys": [
+        "error_visual_sensor_title"
+      ],
+      "subtitleKeys": [
+        "error_visual_sensor_subtitle"
+      ],
+      "descriptionKeys": [
+        "error_visual_sensor_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_visual_sensor_title"
+      ],
+      "fallback": "Camera Error"
+    },
+    "26": {
+      "types": [
+        "LightTouch"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Error_Constants_23"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_43"
+      ],
+      "descriptionKeys": [
+        "light_touch_exception_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_23"
+      ],
+      "fallback": "Wall sensor error"
+    },
+    "27": {
+      "types": [
+        "AudioError",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "tanos_s_error_27_title"
+      ],
+      "subtitleKeys": [
+        "tanos_s_error_27_description"
+      ],
+      "descriptionKeys": [
+        "tanos_s_error_27_description"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "tanos_s_error_27_title"
+      ],
+      "fallback": "Jammed mop module"
+    },
+    "28": {
+      "types": [
+        "CarpetError"
+      ],
+      "titleKeys": [
+        "tanos_s_error_28_title"
+      ],
+      "subtitleKeys": [
+        "tanos_s_error_28_description"
+      ],
+      "descriptionKeys": [
+        "tanos_s_error_28_description"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "tanos_s_error_28_title"
+      ],
+      "fallback": "The robot may be on a carpet"
+    },
+    "29": {
+      "types": [
+        "FindAItem"
+      ],
+      "titleKeys": [
+        "tanos_s_error_29_title",
+        "error_find_a_special_item"
+      ],
+      "subtitleKeys": [
+        "tanos_s_error_29_description",
+        "error_find_a_special_item_detail"
+      ],
+      "descriptionKeys": [
+        "tanos_s_error_29_description",
+        "error_find_a_special_item_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_find_a_special_item",
+        "tanos_s_error_29_title"
+      ],
+      "fallback": "Suspected pet waste found."
+    },
+    "30": {
+      "types": [
+        "ImageFPSError"
+      ],
+      "titleKeys": [],
+      "subtitleKeys": [],
+      "descriptionKeys": [],
+      "detailKeys": [],
+      "labelKeys": [],
+      "fallback": "ImageFPSError"
+    },
+    "32": {
+      "types": [
+        "CollectDustError1",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "collecting_dusk_error32_title"
+      ],
+      "subtitleKeys": [
+        "collecting_dusk_error32_desc"
+      ],
+      "descriptionKeys": [
+        "collecting_dusk_error32_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "collecting_dusk_error32_title"
+      ],
+      "fallback": "No dustbin or filter installed"
+    },
+    "33": {
+      "types": [
+        "Reminder"
+      ],
+      "titleKeys": [
+        "collecting_dusk_error33_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "collecting_dusk_error33_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "collecting_dusk_error33_title"
+      ],
+      "fallback": "Auto-Empty Dock fan error"
+    },
+    "34": {
+      "types": [
+        "CollectDustError3",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "collecting_dusk_error34_title"
+      ],
+      "subtitleKeys": [
+        "collecting_dusk_error34_desc"
+      ],
+      "descriptionKeys": [
+        "collecting_dusk_error34_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "collecting_dusk_error34_title"
+      ],
+      "fallback": "Clean the Auto-Empty Dock bin"
+    },
+    "35": {
+      "types": [
+        "CollectDustError4",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "collecting_dusk_error35_title"
+      ],
+      "subtitleKeys": [
+        "collecting_dusk_error35_desc"
+      ],
+      "descriptionKeys": [
+        "collecting_dusk_error35_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "collecting_dusk_error35_title"
+      ],
+      "fallback": "Auto-Empty Dock voltage error"
+    },
+    "36": {
+      "types": [
+        "MoppingRoller1"
+      ],
+      "titleKeys": [
+        "error_mopping_roller1_title"
+      ],
+      "subtitleKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "descriptionKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_mopping_roller1_title"
+      ],
+      "fallback": "Wash roller may be jammed."
+    },
+    "37": {
+      "types": [
+        "MoppingRollerError2"
+      ],
+      "titleKeys": [
+        "error_mopping_roller2_title"
+      ],
+      "subtitleKeys": [
+        "error_mopping_roller2_desc"
+      ],
+      "descriptionKeys": [
+        "error_mopping_roller2_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_mopping_roller2_title"
+      ],
+      "fallback": "Wash roller not lowered properly."
+    },
+    "38": {
+      "types": [
+        "ClearWaterboxHoare"
+      ],
+      "titleKeys": [
+        "error_clear_waterbox_hoare_title"
+      ],
+      "subtitleKeys": [
+        "error_clear_waterbox_hoare_desc"
+      ],
+      "descriptionKeys": [
+        "error_clear_waterbox_hoare_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_clear_waterbox_hoare_title"
+      ],
+      "fallback": "Check the clean water tank."
+    },
+    "39": {
+      "types": [
+        "DirtyWaterboxHoare"
+      ],
+      "titleKeys": [
+        "error_dirty_waterbox_hoare_title"
+      ],
+      "subtitleKeys": [
+        "error_dirty_waterbox_hoare_desc"
+      ],
+      "descriptionKeys": [
+        "error_dirty_waterbox_hoare_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_dirty_waterbox_hoare_title"
+      ],
+      "fallback": "Check the dirty water tank."
+    },
+    "40": {
+      "types": [
+        "SinkStrainerHoare"
+      ],
+      "titleKeys": [
+        "error_sink_strainer_hoare_title"
+      ],
+      "subtitleKeys": [
+        "error_sink_strainer_hoare_desc"
+      ],
+      "descriptionKeys": [
+        "error_sink_strainer_hoare_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_sink_strainer_hoare_title"
+      ],
+      "fallback": "Water filter not installed."
+    },
+    "41": {
+      "types": [
+        "ClearWaterBoxExcepiton"
+      ],
+      "titleKeys": [
+        "error_clear_waterbox_exception_title"
+      ],
+      "subtitleKeys": [
+        "error_clear_waterbox_exception_desc"
+      ],
+      "descriptionKeys": [
+        "error_clear_waterbox_exception_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_clear_waterbox_exception_title"
+      ],
+      "fallback": "Clean water tank empty."
+    },
+    "42": {
+      "types": [
+        "ClearBrushExcepiton"
+      ],
+      "titleKeys": [
+        "error_clean_bruch_exception_title"
+      ],
+      "subtitleKeys": [
+        "error_clean_brush_exception_desc"
+      ],
+      "descriptionKeys": [
+        "error_clean_brush_exception_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_clean_bruch_exception_title"
+      ],
+      "fallback": "Check that the water filter has been correctly installed."
+    },
+    "43": {
+      "types": [
+        "ClearBrushExcepiton"
+      ],
+      "titleKeys": [
+        "error_main_frame_exception_title"
+      ],
+      "subtitleKeys": [
+        "error_main_frame_exception_desc"
+      ],
+      "descriptionKeys": [
+        "error_main_frame_exception_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_main_frame_exception_title"
+      ],
+      "fallback": "Positioning button Error"
+    },
+    "44": {
+      "types": [
+        "FilterScreenExcepiton"
+      ],
+      "titleKeys": [
+        "error_filter_screen_exception_title"
+      ],
+      "subtitleKeys": [
+        "error_filter_screen_exception_desc"
+      ],
+      "descriptionKeys": [
+        "error_filter_screen_exception_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_filter_screen_exception_title"
+      ],
+      "fallback": "Check and secure the dirty water tank cover"
+    },
+    "45": {
+      "types": [
+        "MoppingRoller1"
+      ],
+      "titleKeys": [
+        "error_mopping_roller1_title"
+      ],
+      "subtitleKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "descriptionKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_mopping_roller1_title"
+      ],
+      "fallback": "Wash roller may be jammed."
+    },
+    "48": {
+      "types": [
+        "UpWaterException"
+      ],
+      "titleKeys": [
+        "error_up_water_title"
+      ],
+      "subtitleKeys": [
+        "error_up_water_desc"
+      ],
+      "descriptionKeys": [
+        "error_up_water_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_up_water_title"
+      ],
+      "fallback": "Refill error"
+    },
+    "49": {
+      "types": [
+        "DrainWaterException"
+      ],
+      "titleKeys": [
+        "error_drain_water_title"
+      ],
+      "subtitleKeys": [
+        "error_drain_water_desc"
+      ],
+      "descriptionKeys": [
+        "error_drain_water_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_drain_water_title"
+      ],
+      "fallback": "Drain error"
+    },
+    "51": {
+      "types": [
+        "TemperatureProtection"
+      ],
+      "titleKeys": [
+        "error_temperature_protection_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_40"
+      ],
+      "descriptionKeys": [
+        "error_temperature_protection_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_temperature_protection_title"
+      ],
+      "fallback": "Unit temperature protection"
+    },
+    "52": {
+      "types": [
+        "CleanCarouselException"
+      ],
+      "titleKeys": [
+        "error_clean_carousel_unsetuped_title"
+      ],
+      "subtitleKeys": [
+        "error_clean_carousel_unsetuped_desc"
+      ],
+      "descriptionKeys": [
+        "error_clean_carousel_unsetuped_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_clean_carousel_unsetuped_title"
+      ],
+      "fallback": "Please check the cleaning tray."
+    },
+    "53": {
+      "types": [
+        "CleanCarouselWaterFull"
+      ],
+      "titleKeys": [
+        "error_clean_carousel_water_full_title"
+      ],
+      "subtitleKeys": [
+        "error_clean_carousel_water_full_desc"
+      ],
+      "descriptionKeys": [
+        "error_clean_carousel_water_full_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_clean_carousel_water_full_title"
+      ],
+      "fallback": "Cleaning tray full."
+    },
+    "54": {
+      "types": [
+        "WaterCarriageDrop"
+      ],
+      "titleKeys": [
+        "error_water_carriage_drop_title"
+      ],
+      "subtitleKeys": [
+        "error_water_carriage_drop_desc"
+      ],
+      "descriptionKeys": [
+        "error_water_carriage_drop_detail"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_water_carriage_drop_title"
+      ],
+      "fallback": "The mop mount fell off. "
+    },
+    "100": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Setting_General_index_0"
+      ],
+      "labelKeys": [
+        "localization_strings_Setting_General_index_0"
+      ],
+      "fallback": "Unknown"
+    },
+    "101": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_3"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_3"
+      ],
+      "fallback": "Compass error"
+    },
+    "102": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_4"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_4"
+      ],
+      "fallback": "Right compass error"
+    },
+    "103": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_5"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_5"
+      ],
+      "fallback": "Main brush short circuit"
+    },
+    "104": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_6"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_6"
+      ],
+      "fallback": "Main brush open circuit"
+    },
+    "105": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_7"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_7"
+      ],
+      "fallback": "Left wheel short circuit"
+    },
+    "106": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_8"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_8"
+      ],
+      "fallback": "Left wheel open circuit"
+    },
+    "107": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_9"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_9"
+      ],
+      "fallback": "Right wheel short circuit"
+    },
+    "108": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_10"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_10"
+      ],
+      "fallback": "Right wheel open circuit."
+    },
+    "109": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_11"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_11"
+      ],
+      "fallback": "Fan open circuit"
+    },
+    "110": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_12"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_12"
+      ],
+      "fallback": "Motion tracking sensor init error"
+    },
+    "111": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_13"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_13"
+      ],
+      "fallback": "Gyroscope init error"
+    },
+    "112": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_14"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_14"
+      ],
+      "fallback": "Charging IC error"
+    },
+    "113": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_15"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_15"
+      ],
+      "fallback": "NVRAM error"
+    },
+    "114": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_16"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_16"
+      ],
+      "fallback": "WiFi module error 1"
+    },
+    "115": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_17"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_17"
+      ],
+      "fallback": "WiFi module error 2"
+    },
+    "116": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_18"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_18"
+      ],
+      "fallback": "ODO error"
+    },
+    "117": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_19"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_19"
+      ],
+      "fallback": "Left ODO error"
+    },
+    "118": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_20"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_20"
+      ],
+      "fallback": "Right ODO error"
+    },
+    "119": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_21"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_21"
+      ],
+      "fallback": "Audio init error"
+    },
+    "120": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_22"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_22"
+      ],
+      "fallback": "Wall sensor init error"
+    },
+    "121": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_23"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_23"
+      ],
+      "fallback": "Wall sensor error"
+    },
+    "122": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_23"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_23"
+      ],
+      "fallback": "Wall sensor error"
+    },
+    "123": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "inner_error_camera_exception"
+      ],
+      "labelKeys": [
+        "inner_error_camera_exception"
+      ],
+      "fallback": "Camera Exception"
+    },
+    "124": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "inner_error_camera_exception"
+      ],
+      "labelKeys": [
+        "inner_error_camera_exception"
+      ],
+      "fallback": "Camera Exception"
+    },
+    "125": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "inner_error_pump_exception"
+      ],
+      "labelKeys": [
+        "inner_error_pump_exception"
+      ],
+      "fallback": "Peristaltic pump abnormality"
+    },
+    "126": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_126"
+      ],
+      "labelKeys": [
+        "inner_error_desc_126"
+      ],
+      "fallback": "Dock Fan Error"
+    },
+    "127": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_127"
+      ],
+      "labelKeys": [
+        "inner_error_desc_127"
+      ],
+      "fallback": "Dock IIC Error"
+    },
+    "128": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "inner_error_desc_128"
+      ],
+      "labelKeys": [
+        "inner_error_desc_128"
+      ],
+      "fallback": "Mopping module short-circuited."
+    },
+    "129": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "inner_error_desc_129"
+      ],
+      "labelKeys": [
+        "inner_error_desc_129"
+      ],
+      "fallback": "Mopping module motor circuit breaker"
+    },
+    "130": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_130"
+      ],
+      "labelKeys": [
+        "inner_error_desc_130"
+      ],
+      "fallback": "No data from clean water tank peristaltic pump ODO"
+    },
+    "131": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_131"
+      ],
+      "labelKeys": [
+        "inner_error_desc_131"
+      ],
+      "fallback": "Over-current of clean water tank peristaltic pump"
+    },
+    "134": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_134"
+      ],
+      "labelKeys": [
+        "inner_error_desc_134"
+      ],
+      "fallback": "Air pump switch error"
+    },
+    "135": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_mopping_roller1_title"
+      ],
+      "subtitleKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "descriptionKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "detailKeys": [
+        "inner_error_desc_135"
+      ],
+      "labelKeys": [
+        "inner_error_desc_135"
+      ],
+      "fallback": "Wash roller locked rotor"
+    },
+    "137": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_mopping_roller1_title"
+      ],
+      "subtitleKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "descriptionKeys": [
+        "error_mopping_roller1_desc"
+      ],
+      "detailKeys": [
+        "inner_error_desc_137"
+      ],
+      "labelKeys": [
+        "inner_error_desc_137"
+      ],
+      "fallback": "Wash roller motor temperature too high"
+    },
+    "138": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_13"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_14"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_14"
+      ],
+      "detailKeys": [
+        "inner_error_desc_138"
+      ],
+      "labelKeys": [
+        "inner_error_desc_138"
+      ],
+      "fallback": "Main brush locked rotor"
+    },
+    "140": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_13"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_14"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_14"
+      ],
+      "detailKeys": [
+        "inner_error_desc_140"
+      ],
+      "labelKeys": [
+        "inner_error_desc_140"
+      ],
+      "fallback": "Main brush motor temperature too high"
+    },
+    "141": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_18"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_19"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_19"
+      ],
+      "detailKeys": [
+        "inner_error_desc_141"
+      ],
+      "labelKeys": [
+        "inner_error_desc_141"
+      ],
+      "fallback": "Left wheel motor temperature too high"
+    },
+    "143": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_18"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_19"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_19"
+      ],
+      "detailKeys": [
+        "inner_error_desc_143"
+      ],
+      "labelKeys": [
+        "inner_error_desc_143"
+      ],
+      "fallback": "Right wheel motor temperature too high"
+    },
+    "145": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_145"
+      ],
+      "labelKeys": [
+        "inner_error_desc_145"
+      ],
+      "fallback": "Dirty water pump error"
+    },
+    "147": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_147"
+      ],
+      "labelKeys": [
+        "inner_error_desc_147"
+      ],
+      "fallback": "Maintenance brush positioning error - left"
+    },
+    "148": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_148"
+      ],
+      "labelKeys": [
+        "inner_error_desc_148"
+      ],
+      "fallback": "Maintenance brush positioning error - middle"
+    },
+    "149": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_149"
+      ],
+      "labelKeys": [
+        "inner_error_desc_149"
+      ],
+      "fallback": "Maintenance brush positioning error - right"
+    },
+    "150": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_150"
+      ],
+      "labelKeys": [
+        "inner_error_desc_150"
+      ],
+      "fallback": "Solenoid valve error"
+    },
+    "151": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_151"
+      ],
+      "labelKeys": [
+        "inner_error_desc_151"
+      ],
+      "fallback": "Drying fan error"
+    },
+    "152": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_152"
+      ],
+      "labelKeys": [
+        "inner_error_desc_152"
+      ],
+      "fallback": "Fill&Drain-discharge pump error"
+    },
+    "153": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_153"
+      ],
+      "labelKeys": [
+        "inner_error_desc_153"
+      ],
+      "fallback": "Fill&Drain-water inlet electronic valve/clean water level Hall sensor error"
+    },
+    "154": {
+      "types": [
+        "Inner",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_48"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_50"
+      ],
+      "detailKeys": [
+        "inner_error_desc_154"
+      ],
+      "labelKeys": [
+        "inner_error_desc_154"
+      ],
+      "fallback": "Side brush error"
+    },
+    "155": {
+      "types": [
+        "Inner",
+        "Reminder"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_51"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_53"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Constants_51"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Constants_51"
+      ],
+      "fallback": "Fan error"
+    },
+    "156": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_156"
+      ],
+      "labelKeys": [
+        "inner_error_desc_156"
+      ],
+      "fallback": "Dock ODD Error"
+    },
+    "157": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_dock_error_title"
+      ],
+      "fallback": "Dock Error"
+    },
+    "158": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_158"
+      ],
+      "labelKeys": [
+        "inner_error_desc_158"
+      ],
+      "fallback": "Fill&Drain- dirty water level Hall sensor error"
+    },
+    "159": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "error_dock_error_title"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_127"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_126"
+      ],
+      "detailKeys": [
+        "inner_error_desc_159"
+      ],
+      "labelKeys": [
+        "inner_error_desc_159"
+      ],
+      "fallback": "Fill&Drain-communication error"
+    },
+    "253": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_4"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_4"
+      ],
+      "fallback": "Right compass error"
+    },
+    "254": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [
+        "localization_strings_Main_Error_Constants_3"
+      ],
+      "labelKeys": [
+        "localization_strings_Main_Error_Constants_3"
+      ],
+      "fallback": "Compass error"
+    },
+    "255": {
+      "types": [
+        "Inner"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_49"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_62"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_60"
+      ],
+      "fallback": "Internal error"
+    },
+    "644": {
+      "types": [
+        "Binfull"
+      ],
+      "titleKeys": [
+        "localization_strings_Main_Constants_63"
+      ],
+      "subtitleKeys": [
+        "localization_strings_Main_Constants_64"
+      ],
+      "descriptionKeys": [
+        "localization_strings_Main_Constants_65"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "localization_strings_Main_Constants_63"
+      ],
+      "fallback": "Empty the dustbin"
+    }
+  }
+}

--- a/lib/protocols/roborock_error_codes.json
+++ b/lib/protocols/roborock_error_codes.json
@@ -7,6 +7,37 @@
       "S7 MaxV/8328da4abbd14f0f99d6c32e17af5a8b/metro_bundle_split/modules/module_1639.js",
       "S7 MaxV/extracted/index.android.bundle",
       "S7 MaxV/extracted/metro_bundle_split/modules/module_1639.js"
+    ],
+    "translationFallbackCodes": [
+      31,
+      56,
+      57,
+      59,
+      60,
+      61,
+      62,
+      64,
+      65,
+      66,
+      67,
+      68,
+      69,
+      70,
+      71,
+      74,
+      76,
+      77,
+      78,
+      79,
+      80,
+      81,
+      82,
+      83,
+      84,
+      85,
+      86,
+      95,
+      97
     ]
   },
   "codes": {
@@ -577,6 +608,25 @@
       "labelKeys": [],
       "fallback": "ImageFPSError"
     },
+    "31": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_31_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_31_desc"
+      ],
+      "detailKeys": [
+        "error_31_detail"
+      ],
+      "labelKeys": [
+        "error_31_title"
+      ],
+      "fallback": "Front and Rear Sensors Error"
+    },
     "32": {
       "types": [
         "CollectDustError1",
@@ -957,6 +1007,532 @@
         "error_water_carriage_drop_title"
       ],
       "fallback": "The mop mount fell off. "
+    },
+    "56": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_56_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_56_desc"
+      ],
+      "fallback": "###"
+    },
+    "57": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_57_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_57_desc"
+      ],
+      "detailKeys": [
+        "error_57_detail"
+      ],
+      "labelKeys": [
+        "error_57_title"
+      ],
+      "fallback": "Cleaning tank maintenance brush error"
+    },
+    "59": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_59_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_59_desc"
+      ],
+      "detailKeys": [
+        "error_59_detail"
+      ],
+      "labelKeys": [
+        "error_59_title"
+      ],
+      "fallback": "###"
+    },
+    "60": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_60_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_60_desc"
+      ],
+      "detailKeys": [
+        "error_60_detail"
+      ],
+      "labelKeys": [
+        "error_60_title"
+      ],
+      "fallback": "###"
+    },
+    "61": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_61_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_61_desc"
+      ],
+      "detailKeys": [
+        "error_61_detail"
+      ],
+      "labelKeys": [
+        "error_61_title"
+      ],
+      "fallback": "请检查激光雷达升降模组"
+    },
+    "62": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_62_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_62_desc"
+      ],
+      "detailKeys": [
+        "error_62_detail"
+      ],
+      "labelKeys": [
+        "error_62_title"
+      ],
+      "fallback": "请检查清洗槽滤网"
+    },
+    "64": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_64_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_64_desc"
+      ],
+      "detailKeys": [
+        "error_64_detail"
+      ],
+      "labelKeys": [
+        "error_64_title"
+      ],
+      "fallback": "机械手压力开关触发"
+    },
+    "65": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_65_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_65_desc"
+      ],
+      "detailKeys": [
+        "error_65_detail"
+      ],
+      "labelKeys": [
+        "error_65_title"
+      ],
+      "fallback": "机械手边缘防夹传感器触发"
+    },
+    "66": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_66_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_66_desc"
+      ],
+      "detailKeys": [
+        "error_66_detail"
+      ],
+      "labelKeys": [
+        "error_66_title"
+      ],
+      "fallback": "舱门开关失败"
+    },
+    "67": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_67_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_67_desc"
+      ],
+      "detailKeys": [
+        "error_67_detail"
+      ],
+      "labelKeys": [
+        "error_67_title"
+      ],
+      "fallback": "机械手卡住"
+    },
+    "68": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_68_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_68_desc"
+      ],
+      "detailKeys": [
+        "error_68_detail"
+      ],
+      "labelKeys": [
+        "error_68_title"
+      ],
+      "fallback": "机械手过流"
+    },
+    "69": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_69_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_69_desc"
+      ],
+      "detailKeys": [
+        "error_69_detail"
+      ],
+      "labelKeys": [
+        "error_69_title"
+      ],
+      "fallback": "机械手状态异常"
+    },
+    "70": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_70_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_70_desc"
+      ],
+      "detailKeys": [
+        "error_70_detail"
+      ],
+      "labelKeys": [
+        "error_70_title"
+      ],
+      "fallback": "机械手温度异常"
+    },
+    "71": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_71_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_71_desc"
+      ],
+      "detailKeys": [
+        "error_71_detail"
+      ],
+      "labelKeys": [
+        "error_71_title"
+      ],
+      "fallback": "机械手被困住"
+    },
+    "74": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_74_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_74_desc"
+      ],
+      "detailKeys": [
+        "error_74_detail"
+      ],
+      "labelKeys": [
+        "error_74_title"
+      ],
+      "fallback": "顶面感知传感器可能脏污"
+    },
+    "76": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_76_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_76_desc"
+      ],
+      "detailKeys": [
+        "error_76_detail"
+      ],
+      "labelKeys": [
+        "error_76_title"
+      ],
+      "fallback": "滚筒未安装"
+    },
+    "77": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_77_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_77_desc"
+      ],
+      "detailKeys": [
+        "error_77_detail"
+      ],
+      "labelKeys": [
+        "error_77_title"
+      ],
+      "fallback": "导水槽未安装"
+    },
+    "78": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_78_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_78_desc"
+      ],
+      "detailKeys": [
+        "error_78_detail"
+      ],
+      "labelKeys": [
+        "error_78_title"
+      ],
+      "fallback": "污水盒未安装"
+    },
+    "79": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_79_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_79_desc"
+      ],
+      "detailKeys": [
+        "error_79_detail"
+      ],
+      "labelKeys": [
+        "error_79_title"
+      ],
+      "fallback": "滚筒掉落"
+    },
+    "80": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_80_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_80_desc"
+      ],
+      "detailKeys": [
+        "error_80_detail"
+      ],
+      "labelKeys": [
+        "error_80_title"
+      ],
+      "fallback": "导水槽掉落"
+    },
+    "81": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_81_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_81_desc"
+      ],
+      "detailKeys": [
+        "error_81_detail"
+      ],
+      "labelKeys": [
+        "error_81_title"
+      ],
+      "fallback": "污水盒掉落"
+    },
+    "82": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_82_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_82_desc"
+      ],
+      "detailKeys": [
+        "error_82_detail"
+      ],
+      "labelKeys": [
+        "error_82_title"
+      ],
+      "fallback": "滚筒罩异常"
+    },
+    "83": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_83_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_83_desc"
+      ],
+      "detailKeys": [
+        "error_83_detail"
+      ],
+      "labelKeys": [
+        "error_83_title"
+      ],
+      "fallback": "基站顶出机构异常"
+    },
+    "84": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_84_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_84_desc"
+      ],
+      "detailKeys": [
+        "error_84_detail"
+      ],
+      "labelKeys": [
+        "error_84_title"
+      ],
+      "fallback": "主机污水盒排水异常"
+    },
+    "85": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_85_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_85_desc"
+      ],
+      "detailKeys": [
+        "error_85_detail"
+      ],
+      "labelKeys": [
+        "error_85_title"
+      ],
+      "fallback": "拖布支架未安装"
+    },
+    "86": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_86_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_86_desc"
+      ],
+      "detailKeys": [
+        "error_86_detail"
+      ],
+      "labelKeys": [
+        "error_86_title"
+      ],
+      "fallback": "支撑臂可能卡入异物"
+    },
+    "95": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_95_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_95_desc"
+      ],
+      "detailKeys": [
+        "error_95_detail"
+      ],
+      "labelKeys": [
+        "error_95_title"
+      ],
+      "fallback": "拖布支架安装失败"
+    },
+    "97": {
+      "types": [
+        "TranslationFallback"
+      ],
+      "titleKeys": [
+        "error_97_title"
+      ],
+      "subtitleKeys": [],
+      "descriptionKeys": [
+        "error_97_desc"
+      ],
+      "detailKeys": [],
+      "labelKeys": [
+        "error_97_title"
+      ],
+      "fallback": "清洁液余量低"
     },
     "100": {
       "types": [

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "appplugins:extract": "node scripts/appplugins.js extract translations",
     "prepare:appplugin-bundles": "node scripts/prepare_appplugin_bundles.js",
     "extract:appplugin-translations": "node scripts/extract_appplugin_translations.js",
+    "extract:appplugin-error-codes": "node scripts/extract_appplugin_error_codes.js --plugin \"S7 MaxV\"",
     "copy:protocols": "shx mkdir -p build/lib/protocols && shx cp lib/protocols/*.json build/lib/protocols/",
     "build:git": "npm run clean && npm run copy:protocols && tsc -b tsconfig.json && npm run build:www",
     "release": "release-script"

--- a/scripts/extract_appplugin_error_codes.js
+++ b/scripts/extract_appplugin_error_codes.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.join(__dirname, "..");
+const DEFAULT_ROOT = path.join(REPO_ROOT, ".AppPlugins");
+const DEFAULT_OUTPUT = path.join(REPO_ROOT, "lib", "protocols", "roborock_error_codes.json");
+const DEFAULT_TRANSLATIONS = path.join(REPO_ROOT, "lib", "protocols", "roborock_strings.json");
+const FIELD_NAMES = ["titleKeys", "subtitleKeys", "descriptionKeys", "detailKeys"];
+
+function parseArgs(argv) {
+	const options = { root: DEFAULT_ROOT, out: DEFAULT_OUTPUT, translations: DEFAULT_TRANSLATIONS, plugin: null };
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg === "--root" && argv[index + 1]) options.root = path.resolve(argv[++index]);
+		else if (arg === "--out" && argv[index + 1]) options.out = path.resolve(argv[++index]);
+		else if (arg === "--translations" && argv[index + 1]) options.translations = path.resolve(argv[++index]);
+		else if (arg === "--plugin" && argv[index + 1]) options.plugin = argv[++index].toLowerCase();
+		else throw new Error(`Unknown or incomplete argument: ${arg}`);
+	}
+	return options;
+}
+
+function walkFiles(rootDir) {
+	const files = [];
+	const pending = [rootDir];
+	while (pending.length > 0) {
+		const current = pending.pop();
+		for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+			const fullPath = path.join(current, entry.name);
+			if (entry.isDirectory()) pending.push(fullPath);
+			else if (entry.isFile() && (entry.name === "index.android.bundle" || /^module_\d+\.js$/.test(entry.name))) files.push(fullPath);
+		}
+	}
+	return files.sort();
+}
+
+function splitTopLevelFields(body) {
+	const fields = [];
+	let current = "";
+	let quote = null;
+	let escaped = false;
+	let depth = 0;
+	for (const char of body) {
+		if (escaped) {
+			current += char;
+			escaped = false;
+			continue;
+		}
+		if (char === "\\" && quote) {
+			current += char;
+			escaped = true;
+			continue;
+		}
+		if (quote) {
+			current += char;
+			if (char === quote) quote = null;
+			continue;
+		}
+		if (char === "'" || char === '"' || char === "`") {
+			quote = char;
+			current += char;
+			continue;
+		}
+		if (char === "(" || char === "[" || char === "{") depth++;
+		if (char === ")" || char === "]" || char === "}") depth--;
+		if (char === "," && depth === 0) {
+			fields.push(current.trim());
+			current = "";
+		} else current += char;
+	}
+	fields.push(current.trim());
+	return fields;
+}
+
+function extractTranslationKeys(expression) {
+	const keys = [];
+	for (const match of expression.matchAll(/(?:^|[^\w$])[$A-Za-z_][\w$]*\.([A-Za-z_][\w]*)/g)) {
+		if (match[1] !== "DMM" && !keys.includes(match[1])) keys.push(match[1]);
+	}
+	return keys;
+}
+
+function parseErrorEntries(source) {
+	const entries = [];
+	const pattern = /(?:(?<=\{)|(?<=,))(\d+):\[(.*?)\](?=,\d+:|\}\})/gs;
+	for (const match of source.matchAll(pattern)) {
+		const fields = splitTopLevelFields(match[2]);
+		const typeMatch = fields[0]?.match(/^['"]([^'"]*)['"]$/);
+		if (!typeMatch || fields.length < 2) continue;
+		entries.push({ code: Number(match[1]), type: typeMatch[1], fields: fields.slice(1, 5).map(extractTranslationKeys) });
+	}
+	return entries;
+}
+
+function parseReminderEntries(source) {
+	const entries = [];
+	const pattern = /(?:^|[,\{])error(\d+):\[(.*?)\](?=,[A-Za-z_]|\}\})/gs;
+	for (const match of source.matchAll(pattern)) {
+		const fields = splitTopLevelFields(match[2]);
+		entries.push({
+			code: Number(match[1]),
+			type: "Reminder",
+			fields: [extractTranslationKeys(fields[0] || ""), [], extractTranslationKeys(fields[1] || ""), []],
+		});
+	}
+	return entries;
+}
+
+function mergeUnique(target, values) {
+	for (const value of values) if (!target.includes(value)) target.push(value);
+}
+
+function selectLabelKeys(code, definition) {
+	if (code >= 100 && code < 600 && definition.detailKeys.length > 0) return [...definition.detailKeys].reverse();
+	return [...definition.titleKeys].reverse();
+}
+
+function buildErrorCodeDataset(rootDir, translationsPath, pluginFilter = null) {
+	const sources = [];
+	const definitions = new Map();
+	for (const filePath of walkFiles(rootDir)) {
+		const relativeSource = path.relative(rootDir, filePath).split(path.sep).join("/");
+		if (pluginFilter && !relativeSource.toLowerCase().includes(pluginFilter)) continue;
+		let source;
+		try {
+			source = fs.readFileSync(filePath, "utf8");
+		} catch {
+			continue;
+		}
+		if (!source.includes("collecting_dusk_error32_title") && !source.includes("error_clear_waterbox_hoare_title")) continue;
+		const entries = [...parseErrorEntries(source), ...parseReminderEntries(source)];
+		if (entries.length === 0) continue;
+		sources.push(relativeSource);
+		for (const entry of entries) {
+			let definition = definitions.get(entry.code);
+			if (!definition) {
+				definition = { types: [], titleKeys: [], subtitleKeys: [], descriptionKeys: [], detailKeys: [] };
+				definitions.set(entry.code, definition);
+			}
+			mergeUnique(definition.types, [entry.type]);
+			entry.fields.forEach((keys, index) => mergeUnique(definition[FIELD_NAMES[index]], keys));
+		}
+	}
+
+	const translations = JSON.parse(fs.readFileSync(translationsPath, "utf8"));
+	const english = translations.en || {};
+	const codes = {};
+	for (const code of [...definitions.keys()].sort((left, right) => left - right)) {
+		const definition = definitions.get(code);
+		const labelKeys = selectLabelKeys(code, definition);
+		const fallback = labelKeys.map((key) => english[key]).find((value) => typeof value === "string" && value.length > 0)
+			|| (code === 0 ? "No error" : definition.types[0] || `Error ${code}`);
+		codes[String(code)] = { ...definition, labelKeys, fallback };
+	}
+	return {
+		_meta: {
+			description: "Roborock AppPlugin error definitions. Translation keys resolve through roborock_strings.json.",
+			pluginFilter,
+			sources: [...new Set(sources)].sort(),
+		},
+		codes,
+	};
+}
+
+function main() {
+	const options = parseArgs(process.argv.slice(2));
+	const dataset = buildErrorCodeDataset(options.root, options.translations, options.plugin);
+	fs.mkdirSync(path.dirname(options.out), { recursive: true });
+	fs.writeFileSync(options.out, `${JSON.stringify(dataset, null, 2)}\n`, "utf8");
+	console.log(`Wrote ${Object.keys(dataset.codes).length} error codes from ${dataset._meta.sources.length} AppPlugin sources to ${options.out}`);
+}
+
+if (require.main === module) main();
+
+module.exports = { buildErrorCodeDataset, extractTranslationKeys, parseErrorEntries, parseReminderEntries, splitTopLevelFields };

--- a/scripts/extract_appplugin_error_codes.js
+++ b/scripts/extract_appplugin_error_codes.js
@@ -113,8 +113,37 @@ function mergeUnique(target, values) {
 }
 
 function selectLabelKeys(code, definition) {
-	if (code >= 100 && code < 600 && definition.detailKeys.length > 0) return [...definition.detailKeys].reverse();
-	return [...definition.titleKeys].reverse();
+	const primaryKeys = code >= 100 && code < 600 && definition.detailKeys.length > 0
+		? definition.detailKeys
+		: definition.titleKeys;
+	if (primaryKeys.length > 0) return [...primaryKeys].reverse();
+	return [definition.descriptionKeys, definition.detailKeys, definition.subtitleKeys].flatMap((keys) => [...keys].reverse());
+}
+
+function addTranslationFallbackDefinitions(definitions, translations) {
+	const structuredCodes = new Set(definitions.keys());
+	for (const locale of Object.values(translations)) {
+		if (!locale || typeof locale !== "object") continue;
+		for (const key of Object.keys(locale)) {
+			const match = key.match(/^error_(\d+)_(title|desc|detail)$/);
+			if (!match) continue;
+
+			const code = Number(match[1]);
+			if (structuredCodes.has(code)) continue;
+			let definition = definitions.get(code);
+			if (!definition) {
+				definition = { types: ["TranslationFallback"], titleKeys: [], subtitleKeys: [], descriptionKeys: [], detailKeys: [] };
+				definitions.set(code, definition);
+			}
+
+			const fieldName = {
+				title: "titleKeys",
+				desc: "descriptionKeys",
+				detail: "detailKeys",
+			}[match[2]];
+			mergeUnique(definition[fieldName], [key]);
+		}
+	}
 }
 
 function buildErrorCodeDataset(rootDir, translationsPath, pluginFilter = null) {
@@ -145,6 +174,7 @@ function buildErrorCodeDataset(rootDir, translationsPath, pluginFilter = null) {
 	}
 
 	const translations = JSON.parse(fs.readFileSync(translationsPath, "utf8"));
+	addTranslationFallbackDefinitions(definitions, translations);
 	const english = translations.en || {};
 	const codes = {};
 	for (const code of [...definitions.keys()].sort((left, right) => left - right)) {
@@ -159,6 +189,9 @@ function buildErrorCodeDataset(rootDir, translationsPath, pluginFilter = null) {
 			description: "Roborock AppPlugin error definitions. Translation keys resolve through roborock_strings.json.",
 			pluginFilter,
 			sources: [...new Set(sources)].sort(),
+			translationFallbackCodes: Object.entries(codes)
+				.filter(([, definition]) => definition.types.includes("TranslationFallback"))
+				.map(([code]) => Number(code)),
 		},
 		codes,
 	};
@@ -174,4 +207,11 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { buildErrorCodeDataset, extractTranslationKeys, parseErrorEntries, parseReminderEntries, splitTopLevelFields };
+module.exports = {
+	addTranslationFallbackDefinitions,
+	buildErrorCodeDataset,
+	extractTranslationKeys,
+	parseErrorEntries,
+	parseReminderEntries,
+	splitTopLevelFields,
+};

--- a/src/lib/features/vacuum/adapterErrorMapping.ts
+++ b/src/lib/features/vacuum/adapterErrorMapping.ts
@@ -1,102 +1,44 @@
-export const ADAPTER_ERROR_MAPPING: Record<number, string> = {
-	1: "localization_strings_Main_Constants_0",
-	2: "localization_strings_Main_Constants_3",
-	3: "localization_strings_Main_Constants_6",
-	4: "localization_strings_Main_Constants_9",
-	5: "localization_strings_Main_Constants_12",
-	6: "localization_strings_Main_Constants_15",
-	7: "localization_strings_Main_Constants_18",
-	8: "localization_strings_Main_Constants_21",
-	9: "localization_strings_Main_Constants_24",
-	10: "localization_strings_Main_Constants_27",
-	11: "localization_strings_Main_Constants_30",
-	12: "localization_strings_Main_Constants_33",
-	13: "localization_strings_Common_Constants_10",
-	14: "localization_strings_Main_Constants_39",
-	15: "localization_strings_Main_Constants_42",
-	16: "localization_strings_Main_Constants_45",
-	17: "localization_strings_Main_Constants_48",
-	18: "localization_strings_Main_Constants_51",
-	19: "localization_strings_Main_Constants_54",
-	21: "rubys_error_21_title",
-	22: "rubys_error_22_title",
-	23: "rubys_error_23_title",
-	24: "error_robot_in_forbidden",
-	25: "error_visual_sensor_title",
-	26: "localization_strings_Main_Error_Constants_23",
-	27: "tanos_s_error_27_title",
-	28: "tanos_s_error_28_title",
-	29: "tanos_s_error_29_title",
-	30: "ImageFPSError",
-	32: "collecting_dusk_error32_title",
-	33: "collecting_dusk_error33_title",
-	34: "collecting_dusk_error34_title",
-	35: "collecting_dusk_error35_title",
-	36: "error_mopping_roller1_title",
-	37: "error_mopping_roller2_title",
-	38: "error_clear_waterbox_hoare_title",
-	39: "error_dirty_waterbox_hoare_title",
-	40: "error_sink_strainer_hoare_title",
-	41: "error_clear_waterbox_exception_title",
-	42: "error_clean_bruch_exception_title",
-	43: "error_main_frame_exception_title",
-	44: "error_filter_screen_exception_title",
-	45: "error_mopping_roller1_title",
-	48: "error_up_water_title",
-	49: "error_drain_water_title",
-	51: "error_temperature_protection_title",
-	52: "error_clean_carousel_unsetuped_title",
-	53: "error_clean_carousel_water_full_title",
-	54: "error_water_carriage_drop_title",
-};
+import errorCodeDataset from "../../../../lib/protocols/roborock_error_codes.json";
 
-export const ADAPTER_ERRORS_EN: Record<string, string> = {
-	"1": "LiDAR Sensor error",
-	"2": "Bumper stuck",
-	"3": "Wheels suspended",
-	"4": "Cliff sensor error",
-	"5": "Main brush jammed.",
-	"6": "Side brush jammed.",
-	"7": "The robot is stuck, or main wheels are jammed.",
-	"8": "The robot is trapped or stuck.",
-	"9": "Dustbin not installed",
-	"10": "Filter is wet or blocked.",
-	"11": "Strong magnetic field detected.",
-	"12": "Low battery",
-	"13": "Charging Error",
-	"14": "Unit temperature protection",
-	"15": "The wall sensor is dirty.",
-	"16": "Robot is tilted",
-	"17": "Side brush error",
-	"18": "Fan error",
-	"19": "Dock not connected to power",
-	"21": "Vertical Bumper Error",
-	"22": "Recharge Sensor Error",
-	"23": "Could not Reach Dock",
-	"24": "No-Go Zone or Invisible Wall detected",
-	"25": "Camera Error",
-	"26": "Wall sensor error",
-	"27": "Jammed mop module",
-	"28": "The robot may be on a carpet",
-	"29": "Unable to cross the carpet",
-	"32": "No dustbin or filter installed",
-	"33": "Auto-Empty Dock fan error",
-	"34": "Clean the Auto-Empty Dock bin",
-	"35": "Auto-Empty Dock voltage error",
-	"36": "Wash roller may be jammed.",
-	"37": "Wash roller not lowered properly.",
-	"38": "Check the clean water tank.",
-	"39": "Check the dirty water tank.",
-	"40": "Water filter not installed.",
-	"41": "Clean water tank empty.",
-	"42": "Check that the water filter has been correctly installed.",
-	"43": "Positioning button Error",
-	"44": "Check and secure the dirty water tank cover",
-	"45": "Wash roller may be jammed.",
-	"48": "Refill error",
-	"49": "Drain error",
-	"51": "Unit temperature protection",
-	"52": "Please check the cleaning tray.",
-	"53": "Cleaning tray full.",
-	"54": "The mop mount fell off. "
-};
+interface ErrorCodeDefinition {
+	types: string[];
+	titleKeys: string[];
+	subtitleKeys: string[];
+	descriptionKeys: string[];
+	detailKeys: string[];
+	labelKeys: string[];
+	fallback: string;
+}
+
+interface ErrorCodeDataset {
+	codes: Record<string, ErrorCodeDefinition>;
+}
+
+interface TranslationLookup {
+	get(key: string, defaultVal?: string): string;
+}
+
+const ERROR_CODE_DEFINITIONS = (errorCodeDataset as ErrorCodeDataset).codes;
+
+export const ADAPTER_ERROR_MAPPING: Record<number, string> = Object.fromEntries(
+	Object.entries(ERROR_CODE_DEFINITIONS)
+		.filter(([, definition]) => definition.labelKeys.length > 0)
+		.map(([code, definition]) => [Number(code), definition.labelKeys[0]]),
+);
+
+export const ADAPTER_ERRORS_EN: Record<string, string> = Object.fromEntries(
+	Object.entries(ERROR_CODE_DEFINITIONS).map(([code, definition]) => [code, definition.fallback]),
+);
+
+/** Resolves the shared AppPlugin namespace used by error_code and dock_error_status. */
+export function getLocalizedErrorStates(translationLookup: TranslationLookup): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(ERROR_CODE_DEFINITIONS).map(([code, definition]) => {
+			for (const key of definition.labelKeys) {
+				const translated = translationLookup.get(key, "");
+				if (translated && translated !== key) return [code, translated];
+			}
+			return [code, definition.fallback];
+		}),
+	);
+}

--- a/src/lib/features/vacuum/v1VacuumFeatures.ts
+++ b/src/lib/features/vacuum/v1VacuumFeatures.ts
@@ -4,6 +4,7 @@ import { Feature } from "../features.enum";
 import { StationService } from "./services/StationService";
 import { V1ConsumableService } from "./services/V1ConsumableService";
 import { V1MapService } from "./services/V1MapService";
+import { getLocalizedErrorStates } from "./adapterErrorMapping";
 import { VACUUM_CONSTANTS } from "./vacuumConstants";
 
 // --- Shared Constants ---
@@ -811,6 +812,7 @@ export class V1VacuumFeatures extends BaseDeviceFeatures {
 
 	public async processStatus(status: any): Promise<void> {
     	const validStatus = status || {};
+		const localizedErrorStates = getLocalizedErrorStates(this.deps.adapter.translationManager);
 
 		if (validStatus.dss !== undefined) {
 			await this.updateDockingStationStatus(Number(validStatus.dss));
@@ -824,9 +826,13 @@ export class V1VacuumFeatures extends BaseDeviceFeatures {
     			await this.deps.adapter.setStateChanged(`Devices.${this.duid}.deviceStatus.state`, { val, ack: true });
     		},
     		error_code: async (val) => {
-    			await this.deps.ensureState(`Devices.${this.duid}.deviceStatus.error_code`, { type: "number", states: this.profile.mappings.error_code || VACUUM_CONSTANTS.errorCodes });
+				await this.deps.ensureState(`Devices.${this.duid}.deviceStatus.error_code`, { type: "number", states: this.profile.mappings.error_code || localizedErrorStates });
     			await this.deps.adapter.setStateChanged(`Devices.${this.duid}.deviceStatus.error_code`, { val, ack: true });
     		},
+			dock_error_status: async (val) => {
+				await this.deps.ensureState(`Devices.${this.duid}.deviceStatus.dock_error_status`, { type: "number", states: localizedErrorStates });
+				await this.deps.adapter.setStateChanged(`Devices.${this.duid}.deviceStatus.dock_error_status`, { val, ack: true });
+			},
     		fan_power: async (val) => {
     			await this.deps.ensureState(`Devices.${this.duid}.deviceStatus.fan_power`, { type: "number", states: this.profile.mappings.fan_power });
     			await this.deps.adapter.setStateChanged(`Devices.${this.duid}.deviceStatus.fan_power`, { val, ack: true });

--- a/test/unit/dock_error_mapping.test.ts
+++ b/test/unit/dock_error_mapping.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import errorCodeDataset from "../../lib/protocols/roborock_error_codes.json";
+import { FeatureDependencies } from "../../src/lib/features/baseDeviceFeatures";
+import { A62Features } from "../../src/lib/features/vacuum/a62_features";
+import { getLocalizedErrorStates } from "../../src/lib/features/vacuum/adapterErrorMapping";
+
+vi.mock("../../src/lib/map/MapManager", () => ({
+	MapManager: class {
+		processMap = vi.fn().mockResolvedValue({ mapBase64: "base64_map" });
+	},
+}));
+
+describe("AppPlugin error mapping", () => {
+	it("contains the complete extracted AppPlugin union", () => {
+		expect(Object.keys(errorCodeDataset.codes)).toHaveLength(107);
+		expect(errorCodeDataset.codes["29"].titleKeys).not.toContain("DMM");
+		expect(errorCodeDataset.codes["38"]).toMatchObject({
+			types: ["ClearWaterboxHoare"],
+			labelKeys: ["error_clear_waterbox_hoare_title"],
+			fallback: "Check the clean water tank.",
+		});
+		expect(errorCodeDataset.codes["33"].titleKeys).toContain("collecting_dusk_error33_title");
+		expect(errorCodeDataset.codes["159"].detailKeys).toContain("inner_error_desc_159");
+	});
+
+	it("resolves states in the configured adapter language", () => {
+		const states = getLocalizedErrorStates({
+			get: (key, fallback) => key === "error_clear_waterbox_hoare_title"
+				? "Bitte den Reinwassertank überprüfen"
+				: fallback || key,
+		});
+
+		expect(states["38"]).toBe("Bitte den Reinwassertank überprüfen");
+		expect(states["33"]).toBe("Auto-Empty Dock fan error");
+	});
+
+	it("applies the same localized states to error_code and dock_error_status", async () => {
+		const ensureState = vi.fn().mockResolvedValue(undefined);
+		const setStateChanged = vi.fn().mockResolvedValue(undefined);
+		const adapter = {
+			log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() },
+			setStateChanged,
+			requestsHandler: { sendRequest: vi.fn(), command: vi.fn() },
+			translationManager: {
+				get: (key: string, fallback?: string) => key === "error_clear_waterbox_hoare_title"
+					? "Bitte den Reinwassertank überprüfen"
+					: fallback || key,
+			},
+			rLog: vi.fn(),
+		} as any;
+		const dependencies = {
+			adapter,
+			ensureState,
+			ensureFolder: vi.fn().mockResolvedValue(undefined),
+			log: adapter.log,
+		} as unknown as FeatureDependencies;
+		const vacuum = new A62Features(dependencies, "a62-duid");
+
+		await vacuum.processStatus({ error_code: 0, dock_error_status: 38 });
+
+		const errorObject = ensureState.mock.calls.find(([id]) => id.endsWith("deviceStatus.error_code"));
+		const dockErrorObject = ensureState.mock.calls.find(([id]) => id.endsWith("deviceStatus.dock_error_status"));
+		expect(errorObject?.[1].states["38"]).toBe("Bitte den Reinwassertank überprüfen");
+		expect(dockErrorObject?.[1].states).toEqual(errorObject?.[1].states);
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.a62-duid.deviceStatus.dock_error_status", { val: 38, ack: true });
+	});
+});

--- a/test/unit/dock_error_mapping.test.ts
+++ b/test/unit/dock_error_mapping.test.ts
@@ -11,8 +11,8 @@ vi.mock("../../src/lib/map/MapManager", () => ({
 }));
 
 describe("AppPlugin error mapping", () => {
-	it("contains the complete extracted AppPlugin union", () => {
-		expect(Object.keys(errorCodeDataset.codes)).toHaveLength(107);
+	it("contains the AppPlugin union and translation-defined fallback codes", () => {
+		expect(Object.keys(errorCodeDataset.codes)).toHaveLength(136);
 		expect(errorCodeDataset.codes["29"].titleKeys).not.toContain("DMM");
 		expect(errorCodeDataset.codes["38"]).toMatchObject({
 			types: ["ClearWaterboxHoare"],
@@ -21,16 +21,24 @@ describe("AppPlugin error mapping", () => {
 		});
 		expect(errorCodeDataset.codes["33"].titleKeys).toContain("collecting_dusk_error33_title");
 		expect(errorCodeDataset.codes["159"].detailKeys).toContain("inner_error_desc_159");
+		expect(errorCodeDataset.codes["95"]).toMatchObject({
+			types: ["TranslationFallback"],
+			labelKeys: ["error_95_title"],
+		});
+		expect(errorCodeDataset.codes["95"].fallback).toBeTruthy();
+		expect(errorCodeDataset._meta.translationFallbackCodes).toContain(95);
 	});
 
 	it("resolves states in the configured adapter language", () => {
 		const states = getLocalizedErrorStates({
-			get: (key, fallback) => key === "error_clear_waterbox_hoare_title"
-				? "Bitte den Reinwassertank überprüfen"
-				: fallback || key,
+			get: (key, fallback) => ({
+				error_clear_waterbox_hoare_title: "Bitte den Reinwassertank überprüfen",
+				error_95_title: "Installation der Wischtuschhalterung fehlgeschlagen",
+			}[key] || fallback || key),
 		});
 
 		expect(states["38"]).toBe("Bitte den Reinwassertank überprüfen");
+		expect(states["95"]).toBe("Installation der Wischtuschhalterung fehlgeschlagen");
 		expect(states["33"]).toBe("Auto-Empty Dock fan error");
 	});
 
@@ -42,9 +50,10 @@ describe("AppPlugin error mapping", () => {
 			setStateChanged,
 			requestsHandler: { sendRequest: vi.fn(), command: vi.fn() },
 			translationManager: {
-				get: (key: string, fallback?: string) => key === "error_clear_waterbox_hoare_title"
-					? "Bitte den Reinwassertank überprüfen"
-					: fallback || key,
+				get: (key: string, fallback?: string) => ({
+					error_clear_waterbox_hoare_title: "Bitte den Reinwassertank überprüfen",
+					error_95_title: "Installation der Wischtuschhalterung fehlgeschlagen",
+				}[key] || fallback || key),
 			},
 			rLog: vi.fn(),
 		} as any;
@@ -63,5 +72,34 @@ describe("AppPlugin error mapping", () => {
 		expect(errorObject?.[1].states["38"]).toBe("Bitte den Reinwassertank überprüfen");
 		expect(dockErrorObject?.[1].states).toEqual(errorObject?.[1].states);
 		expect(setStateChanged).toHaveBeenCalledWith("Devices.a62-duid.deviceStatus.dock_error_status", { val: 38, ack: true });
+	});
+
+	it("exposes the observed mop-cloth-mount error through error_code", async () => {
+		const ensureState = vi.fn().mockResolvedValue(undefined);
+		const setStateChanged = vi.fn().mockResolvedValue(undefined);
+		const adapter = {
+			log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() },
+			setStateChanged,
+			requestsHandler: { sendRequest: vi.fn(), command: vi.fn() },
+			translationManager: {
+				get: (key: string, fallback?: string) => key === "error_95_title"
+					? "Installation der Wischtuschhalterung fehlgeschlagen"
+					: fallback || key,
+			},
+			rLog: vi.fn(),
+		} as any;
+		const dependencies = {
+			adapter,
+			ensureState,
+			ensureFolder: vi.fn().mockResolvedValue(undefined),
+			log: adapter.log,
+		} as unknown as FeatureDependencies;
+		const vacuum = new A62Features(dependencies, "a62-duid");
+
+		await vacuum.processStatus({ error_code: 95 });
+
+		const errorObject = ensureState.mock.calls.find(([id]) => id.endsWith("deviceStatus.error_code"));
+		expect(errorObject?.[1].states["95"]).toBe("Installation der Wischtuschhalterung fehlgeschlagen");
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.a62-duid.deviceStatus.error_code", { val: 95, ack: true });
 	});
 });


### PR DESCRIPTION
## Root cause

The S7 Pro Ultra reports dock warnings through `get_status.dock_error_status`. The AppPlugin treats that value as part of the same error namespace as `error_code`, but the adapter exposed it only as an unmapped number.

## Changes

- extract the complete S7 MaxV AppPlugin error table into a reproducible JSON dataset
- retain title, subtitle, description, detail, fallback, and translation keys for 107 error codes
- resolve the mapping through the adapter's selected language and existing `roborock_strings.json`
- apply the same localized `common.states` mapping to `error_code` and `dock_error_status`
- add regression coverage for S7 Pro Ultra code `38`

## User impact

For the reported warning, `dock_error_status = 38` is now shown as the localized clean-water-tank warning instead of only the raw number. Existing ioBroker objects are updated when their states mapping differs.

## Validation

- `npm run test:unit` — 272 tests passed
- `npm run lint`
- `tsc --noEmit`
- regenerated JSON matched the committed output byte-for-byte

Fixes #1359
