### PR TITLE
Fix Roborock Q7 Pro B01 status and consumables

### DIFF
--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -101,8 +101,8 @@ export class DeviceManager {
 		"127": "filter_life",
 	};
 	private static readonly Q7_HOME_DATA_CONSUMABLE_MAP: Record<string, string> = {
-		"125": "side_brush_life",
-		"127": "filter_life",
+		// Q7 HomeData consumables are stale/incomplete and can overwrite the
+		// live prop.get values. Q7 consumables must come from B01 prop.get.
 	};
 	// Interval handle
 	private mainUpdateInterval: ioBroker.Interval | undefined = undefined;

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -516,7 +516,8 @@ export class DeviceManager {
 			if (!mappedName) continue;
 
 			if (typeof value !== "number" || !Number.isInteger(value)) continue;
-			const val = value >= 0 && value <= 100 ? value : 0;
+			if (value < 0 || value > 100) continue;
+			const val = value;
 
 			const common = handler.getCommonConsumable(mappedName); // Use mapped name
 

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -100,6 +100,10 @@ export class DeviceManager {
 		"126": "side_brush_life",
 		"127": "filter_life",
 	};
+	private static readonly Q7_HOME_DATA_CONSUMABLE_MAP: Record<string, string> = {
+		"125": "side_brush_life",
+		"127": "filter_life",
+	};
 	// Interval handle
 	private mainUpdateInterval: ioBroker.Interval | undefined = undefined;
 	private pollingDevices = new Set<string>();
@@ -107,6 +111,12 @@ export class DeviceManager {
 
 	constructor(adapter: Roborock) {
 		this.adapter = adapter;
+	}
+
+	private getHomeDataConsumableMap(handler: BaseDeviceFeatures): Record<string, string> {
+		return (handler as unknown as { b01Variant?: string }).b01Variant === "Q7"
+			? DeviceManager.Q7_HOME_DATA_CONSUMABLE_MAP
+			: DeviceManager.HOME_DATA_CONSUMABLE_MAP;
 	}
 
 	/**
@@ -523,7 +533,7 @@ export class DeviceManager {
 				continue;
 			}
 
-			const mappedName = DeviceManager.HOME_DATA_CONSUMABLE_MAP[attribute];
+			const mappedName = this.getHomeDataConsumableMap(handler)[attribute];
 			if (!mappedName) continue;
 
 			if (typeof value !== "number" || !Number.isInteger(value)) continue;

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -92,6 +92,14 @@ function createFeaturesForModel(adapter: Roborock, duid: string, robotModel: str
 
 export class DeviceManager {
 	private adapter: Roborock;
+	private static readonly HOME_DATA_DEVICE_STATUS_MAP: Record<string, string> = {
+		"122": "battery",
+	};
+	private static readonly HOME_DATA_CONSUMABLE_MAP: Record<string, string> = {
+		"125": "main_brush_life",
+		"126": "side_brush_life",
+		"127": "filter_life",
+	};
 	// Interval handle
 	private mainUpdateInterval: ioBroker.Interval | undefined = undefined;
 	private pollingDevices = new Set<string>();
@@ -148,7 +156,7 @@ export class DeviceManager {
 					});
 
 					await this.adapter.updateDeviceInfo(duid, devices);
-					await this.updateConsumablesPercent(duid, devices);
+					await this.updateHomeDataDeviceStatus(duid, devices);
 
 					// Apply static features
 					await handler.initialize(device.online);
@@ -299,7 +307,7 @@ export class DeviceManager {
 				try {
 					if (isSlowTick) {
 						await this.adapter.updateDeviceInfo(duid, cloudDevices);
-						await this.updateConsumablesPercent(duid, cloudDevices);
+						await this.updateHomeDataDeviceStatus(duid, cloudDevices);
 					}
 					if (!device.online) continue;
 					const version = await this.adapter.getDeviceProtocolVersion(duid);
@@ -494,9 +502,9 @@ export class DeviceManager {
 	}
 
 	/**
-	 * Fetches consumable percentages.
+	 * Applies numeric device.status values from cloud HomeData.
 	 */
-	public async updateConsumablesPercent(duid: string, devices = this.adapter.http_api.getDevices()): Promise<void> {
+	public async updateHomeDataDeviceStatus(duid: string, devices = this.adapter.http_api.getDevices()): Promise<void> {
 		const handler = this.deviceFeatureHandlers.get(duid);
 		if (!handler) return;
 
@@ -504,25 +512,27 @@ export class DeviceManager {
 		if (!device?.deviceStatus) return; // 'deviceStatus' exists on Device type
 		const status = device.deviceStatus as Record<string, unknown>;
 
-		const consumableMap: Record<string, string> = {
-			"125": "main_brush_life",
-			"126": "side_brush_life",
-			"127": "filter_life",
-		};
-
 		for (const [attribute, value] of Object.entries(status)) {
-			// Cloud consumable percentages
-			const mappedName = consumableMap[attribute];
+			const statusName = DeviceManager.HOME_DATA_DEVICE_STATUS_MAP[attribute];
+			if (statusName) {
+				if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 100) continue;
+				const common = handler.getCommonDeviceStates(statusName);
+
+				await this.adapter.ensureState(`Devices.${duid}.deviceStatus.${statusName}`, common || {});
+				await this.adapter.setStateChanged(`Devices.${duid}.deviceStatus.${statusName}`, { val: value, ack: true });
+				continue;
+			}
+
+			const mappedName = DeviceManager.HOME_DATA_CONSUMABLE_MAP[attribute];
 			if (!mappedName) continue;
 
 			if (typeof value !== "number" || !Number.isInteger(value)) continue;
 			if (value < 0 || value > 100) continue;
-			const val = value;
 
 			const common = handler.getCommonConsumable(mappedName); // Use mapped name
 
 			await this.adapter.ensureState(`Devices.${duid}.consumables.${mappedName}`, common || {});
-			await this.adapter.setStateChanged(`Devices.${duid}.consumables.${mappedName}`, { val, ack: true });
+			await this.adapter.setStateChanged(`Devices.${duid}.consumables.${mappedName}`, { val: value, ack: true });
 		}
 	}
 }

--- a/src/lib/features/vacuum/b01/B01BaseVacuumFeatures.ts
+++ b/src/lib/features/vacuum/b01/B01BaseVacuumFeatures.ts
@@ -26,6 +26,15 @@ export class B01BaseVacuumFeatures extends BaseDeviceFeatures {
 	public readonly b01Variant: B01Variant;
 
 	protected mappedRooms: Array<{ id: number; name: string }> | null = null;
+	private static readonly STANDARD_STATUS_ALIASES: Record<string, string[]> = {
+		quantity: ["battery"],
+		fault: ["error_code"],
+		wind: ["fan_power"],
+		water: ["water_box_mode"],
+		sweep_type: ["mop_mode"],
+		cleaning_time: ["clean_time"],
+		cleaning_area: ["clean_area"],
+	};
 
 	protected async cleanupVariantCommandObjects(): Promise<void> {
 		return;
@@ -417,6 +426,9 @@ export class B01BaseVacuumFeatures extends BaseDeviceFeatures {
 		await this.deps.ensureFolder(`Devices.${this.duid}.deviceStatus`);
 		for (const key in resultObj) {
 			await this.processStatusProperty(key, resultObj[key]);
+			for (const alias of B01BaseVacuumFeatures.STANDARD_STATUS_ALIASES[key] || []) {
+				await this.processStatusProperty(alias, resultObj[key]);
+			}
 		}
 	}
 
@@ -427,7 +439,7 @@ export class B01BaseVacuumFeatures extends BaseDeviceFeatures {
 		const cleanModeValue = resultObj.clean_mode ?? resultObj.cleanMode ?? resultObj.mode;
 		const faultValue = resultObj.fault ?? resultObj.error_code;
 		const dustCollectValue = resultObj.dust_action ?? resultObj.dust_collection_status;
-		const batteryValue = resultObj.battery;
+		const batteryValue = resultObj.battery ?? resultObj.quantity;
 
 		if (stateValue !== undefined && stateValue !== null) nextStatus.deviceState = Number(stateValue);
 		if (workModeValue !== undefined && workModeValue !== null) nextStatus.deviceWorkMode = Number(workModeValue);
@@ -715,6 +727,13 @@ export class B01BaseVacuumFeatures extends BaseDeviceFeatures {
 			};
 		}
 		if (attribute === "quantity") {
+			return {
+				type: "number",
+				name: this.locales.getNameAll(String(attribute)),
+				unit: "%"
+			};
+		}
+		if (attribute === "battery") {
 			return {
 				type: "number",
 				name: this.locales.getNameAll(String(attribute)),

--- a/src/lib/features/vacuum/b01/B01BaseVacuumFeatures.ts
+++ b/src/lib/features/vacuum/b01/B01BaseVacuumFeatures.ts
@@ -341,6 +341,7 @@ export class B01BaseVacuumFeatures extends BaseDeviceFeatures {
 		await Promise.all([
 			this.updateFirmwareFeatures(),
 			this.updateExtraStatus(),
+			this.updateConsumables(),
 			this.updateNetworkInfo(),
 			this.updateTimers()
 		]);

--- a/src/lib/features/vacuum/services/B01ConsumableService.ts
+++ b/src/lib/features/vacuum/services/B01ConsumableService.ts
@@ -74,19 +74,18 @@ export class B01ConsumableService {
 				suffix = " cycles";
 			} else if (key.endsWith("_work_time") || key.endsWith("_dirty_time")) {
 				const totalHours = this.getConsumableLifeSpan(deviceName);
-				const totalSeconds = totalHours * 3600;
-				const usedSeconds = Number(val);
-				if (!Number.isFinite(usedSeconds)) continue;
+				const totalMinutes = totalHours * 60;
+				const usedMinutes = this.normalizeConsumableUsedMinutes(val, totalMinutes);
+				if (!Number.isFinite(usedMinutes)) continue;
 
-				if (totalSeconds > 0) {
-					// Convert seconds used to remaining hours
-					val = Math.max(0, Math.round((totalSeconds - usedSeconds) / 3600));
+				if (totalMinutes > 0) {
+					val = Math.max(0, Math.round((totalMinutes - usedMinutes) / 60));
 					unit = "h";
 					suffix = " remaining time";
 
 					const lifeState = this.LIFE_STATE_MAP[deviceName];
 					if (lifeState) {
-						const remainingPercent = Math.max(0, Math.min(100, Math.round(((totalSeconds - usedSeconds) / totalSeconds) * 100)));
+						const remainingPercent = Math.max(0, Math.min(100, Math.ceil(((totalMinutes - usedMinutes) / totalMinutes) * 100)));
 						const common = VACUUM_CONSTANTS.consumables[lifeState as keyof typeof VACUUM_CONSTANTS.consumables];
 						await this.stateWriter.ensureAndSetValueState(`consumables.${lifeState}`, {
 							name: `${localizedName} remaining life`,
@@ -118,6 +117,13 @@ export class B01ConsumableService {
 				def: false
 			}, { resetParam: key });
 		}
+	}
+
+	private normalizeConsumableUsedMinutes(value: unknown, totalMinutes: number): number {
+		const numericValue = Number(value);
+		if (!Number.isFinite(numericValue)) return Number.NaN;
+
+		return totalMinutes > 0 && numericValue > totalMinutes ? numericValue / 60 : numericValue;
 	}
 
 	private getConsumableLifeSpan(deviceName: string): number {

--- a/src/lib/features/vacuum/services/B01ConsumableService.ts
+++ b/src/lib/features/vacuum/services/B01ConsumableService.ts
@@ -20,6 +20,12 @@ export class B01ConsumableService {
 		filter_element: "filter_element_work_time"
 	};
 
+	private readonly LIFE_STATE_MAP: Record<string, string> = {
+		main_brush: "main_brush_life",
+		side_brush: "side_brush_life",
+		filter: "filter_life"
+	};
+
 	public async updateConsumables(data?: unknown): Promise<void> {
 		let resultObj: Record<string, any> | undefined;
 
@@ -67,13 +73,26 @@ export class B01ConsumableService {
 				unit = "cycles";
 				suffix = " cycles";
 			} else if (key.endsWith("_work_time") || key.endsWith("_dirty_time")) {
-				const totalSeconds = this.getConsumableLifeSpan(deviceName) * 3600;
+				const totalHours = this.getConsumableLifeSpan(deviceName);
+				const totalSeconds = totalHours * 3600;
+				const usedSeconds = Number(val);
+				if (!Number.isFinite(usedSeconds)) continue;
 
 				if (totalSeconds > 0) {
 					// Convert seconds used to remaining hours
-					val = Math.max(0, Math.round((totalSeconds - val) / 3600));
+					val = Math.max(0, Math.round((totalSeconds - usedSeconds) / 3600));
 					unit = "h";
 					suffix = " remaining time";
+
+					const lifeState = this.LIFE_STATE_MAP[deviceName];
+					if (lifeState) {
+						const remainingPercent = Math.max(0, Math.min(100, Math.round(((totalSeconds - usedSeconds) / totalSeconds) * 100)));
+						const common = VACUUM_CONSTANTS.consumables[lifeState as keyof typeof VACUUM_CONSTANTS.consumables];
+						await this.stateWriter.ensureAndSetValueState(`consumables.${lifeState}`, {
+							name: `${localizedName} remaining life`,
+							...common
+						}, remainingPercent);
+					}
 				} else {
 					unit = "s";
 					suffix = " work time";

--- a/src/lib/mqttApi.test.ts
+++ b/src/lib/mqttApi.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { mqtt_api } from "./mqttApi";
+
+describe("mqtt_api B01 protocol 102 dispatch", () => {
+	it("resolves Q7-style dps.10001 RPC replies delivered as protocol 102 frames", async () => {
+		const duid = "duid-q7";
+		const requestId = 1783006488697;
+		const resolvePendingRequest = vi.fn();
+		const adapter = {
+			pendingRequests: new Map([[requestId, { duid, method: "prop.get", version: "B01" }]]),
+			requestsHandler: {
+				resolvePendingRequest,
+				isRequestRecentlyFinished: vi.fn(() => false),
+			},
+			deviceFeatureHandlers: new Map(),
+			getB01Variant: vi.fn().mockResolvedValue("Q7"),
+			getDeviceProtocolVersion: vi.fn().mockResolvedValue("B01"),
+			rLog: vi.fn(),
+			setInterval: vi.fn(() => 1),
+			clearInterval: vi.fn(),
+			errorStack: (error: unknown) => error instanceof Error ? error.stack || error.message : String(error),
+		};
+		const api = new mqtt_api(adapter as any);
+
+		await api.handleDecodedMessage(duid, {
+			version: "B01",
+			protocol: 102,
+			payload: Buffer.from(JSON.stringify({
+				t: 1783006491,
+				dps: {
+					"10001": JSON.stringify({
+						msgId: String(requestId),
+						code: 1,
+						method: "prop.get",
+						data: {
+							status: 4,
+							quantity: 100,
+						},
+					}),
+				},
+			})),
+		});
+
+		expect(resolvePendingRequest).toHaveBeenCalledWith(
+			requestId,
+			{ status: 4, quantity: 100 },
+			"MQTT-B01",
+			duid,
+			"MQTT",
+		);
+	});
+});

--- a/src/lib/mqttApi.ts
+++ b/src/lib/mqttApi.ts
@@ -405,19 +405,34 @@ export class mqtt_api {
 	 */
 	private async dispatchB01Message(duid: string, parsedPayload: any): Promise<void> {
 		// Standard B01 Wrapper: { dps: { "10001": { ... } } }
-		if (parsedPayload.dps?.["10001"]) {
-			let inner = parsedPayload.dps["10001"];
-
-			if (typeof inner === "string") {
-				try {
-					inner = JSON.parse(inner);
-				} catch (e) {
-					this.adapter.rLog("MQTT", duid, "Error", "B01", undefined, `Failed to parse B01 nested string payload: ${e}`, "warn");
-					return;
-				}
-			}
-			await this.handleB01Response(inner, duid);
+		if (parsedPayload.dps?.["10001"] !== undefined) {
+			await this.dispatchB01Dps10001(duid, parsedPayload.dps["10001"]);
 		}
+	}
+
+	private parseB01Dps10001(duid: string, value: unknown): Record<string, unknown> | null {
+		let inner = value;
+
+		if (typeof inner === "string") {
+			try {
+				inner = JSON.parse(inner);
+			} catch (e) {
+				this.adapter.rLog("MQTT", duid, "Error", "B01", undefined, `Failed to parse B01 nested string payload: ${e}`, "warn");
+				return null;
+			}
+		}
+
+		return inner && typeof inner === "object" && !Array.isArray(inner)
+			? inner as Record<string, unknown>
+			: null;
+	}
+
+	private async dispatchB01Dps10001(duid: string, value: unknown): Promise<boolean> {
+		const inner = this.parseB01Dps10001(duid, value);
+		if (!inner) return false;
+
+		await this.handleB01Response(inner, duid);
+		return true;
 	}
 
 	/**
@@ -428,12 +443,15 @@ export class mqtt_api {
 			const payloadStr = Buffer.isBuffer(data.payload) ? data.payload.toString("utf8") : String(data.payload ?? "");
 			const parsed = JSON.parse(payloadStr);
 
-			if (data.version === "B01" && parsed.dps?.["10001"]) {
-				await this.dispatchB01Message(duid, parsed);
+			if (data.version === "B01" && parsed.dps?.["10001"] !== undefined) {
+				await this.dispatchB01Dps10001(duid, parsed.dps["10001"]);
 				return;
 			}
 
-			let dps102 = parsed.dps?.["102"] || (parsed.dps ? parsed.dps : null);
+			let dps102 =
+				parsed.dps?.["102"] ??
+				(parsed.dps ? parsed.dps : null) ??
+				(parsed && typeof parsed === "object" && ("id" in parsed || "result" in parsed) ? parsed : null);
 			const b01Variant = await this.adapter.getB01Variant(duid);
 			const handler = this.adapter.deviceFeatureHandlers.get(duid);
 

--- a/test/unit/DeterministicLogic.test.ts
+++ b/test/unit/DeterministicLogic.test.ts
@@ -40,30 +40,30 @@ describe("Deterministic Logic Verification", () => {
 		});
 	});
 
-	describe("Hour Conversion Logic", () => {
-		it("should correctly convert seconds used to remaining hours (300h life, 150h used)", () => {
+	describe("B01 Minute Conversion Logic", () => {
+		it("should correctly convert used minutes to remaining hours (300h life, 150h used)", () => {
 			const totalLifeHours = 300;
-			const usedSeconds = 150 * 3600;
-			const totalSeconds = totalLifeHours * 3600;
-			const remainingHours = Math.max(0, Math.round((totalSeconds - usedSeconds) / 3600));
+			const usedMinutes = 150 * 60;
+			const totalMinutes = totalLifeHours * 60;
+			const remainingHours = Math.max(0, Math.round((totalMinutes - usedMinutes) / 60));
 
 			expect(remainingHours).toBe(150);
 		});
 
-		it("should correctly convert seconds used to remaining hours (200h life, 150h used)", () => {
+		it("should correctly convert used minutes to remaining hours (200h life, 150h used)", () => {
 			const totalLifeHours = 200;
-			const usedSeconds = 150 * 3600;
-			const totalSeconds = totalLifeHours * 3600;
-			const remainingHours = Math.max(0, Math.round((totalSeconds - usedSeconds) / 3600));
+			const usedMinutes = 150 * 60;
+			const totalMinutes = totalLifeHours * 60;
+			const remainingHours = Math.max(0, Math.round((totalMinutes - usedMinutes) / 60));
 
 			expect(remainingHours).toBe(50);
 		});
 
 		it("should handle over-usage (returning 0h)", () => {
 			const totalLifeHours = 150;
-			const usedSeconds = 200 * 3600;
-			const totalSeconds = totalLifeHours * 3600;
-			const remainingHours = Math.max(0, Math.round((totalSeconds - usedSeconds) / 3600));
+			const usedMinutes = 200 * 60;
+			const totalMinutes = totalLifeHours * 60;
+			const remainingHours = Math.max(0, Math.round((totalMinutes - usedMinutes) / 60));
 
 			expect(remainingHours).toBe(0);
 		});

--- a/test/unit/b01_status_normalization.test.ts
+++ b/test/unit/b01_status_normalization.test.ts
@@ -16,6 +16,7 @@ function createDeps() {
 			setStateChanged,
 			rLog: vi.fn(),
 			formatRoborockDate: vi.fn((value: number) => String(value)),
+			checkForNewFirmware: vi.fn().mockResolvedValue(undefined),
 			errorMessage: vi.fn((error: unknown) => error instanceof Error ? error.message : String(error)),
 		} as any,
 		config: {} as any,
@@ -58,5 +59,36 @@ describe("B01 status normalization", () => {
 			deviceFault: 0,
 			deviceWorkMode: 1,
 		}));
+	});
+
+	it("loads B01 consumables during initial online data refresh", async () => {
+		const { deps } = createDeps();
+		const feature = new Q7VacuumFeatures(deps, "duid-q7", "roborock.vacuum.sc01", { staticFeatures: [] });
+		const calls: string[] = [];
+
+		vi.spyOn(feature as any, "updateStatus").mockImplementation(async () => { calls.push("status"); });
+		vi.spyOn(feature as any, "updateMap").mockImplementation(async () => { calls.push("map"); });
+		vi.spyOn(feature as any, "updateMultiMapsList").mockImplementation(async () => { calls.push("multiMap"); });
+		vi.spyOn(feature as any, "updateRoomMapping").mockImplementation(async () => { calls.push("rooms"); });
+		vi.spyOn(feature as any, "updateFirmwareFeatures").mockImplementation(async () => { calls.push("firmware"); });
+		vi.spyOn(feature as any, "updateExtraStatus").mockImplementation(async () => { calls.push("extra"); });
+		vi.spyOn(feature as any, "updateConsumables").mockImplementation(async () => { calls.push("consumables"); });
+		vi.spyOn(feature as any, "updateNetworkInfo").mockImplementation(async () => { calls.push("network"); });
+		vi.spyOn(feature as any, "updateTimers").mockImplementation(async () => { calls.push("timers"); });
+
+		await feature.initializeDeviceData();
+
+		expect(calls).toEqual(expect.arrayContaining([
+			"status",
+			"map",
+			"multiMap",
+			"rooms",
+			"firmware",
+			"extra",
+			"consumables",
+			"network",
+			"timers",
+		]));
+		expect(feature.updateConsumables).toHaveBeenCalledTimes(1);
 	});
 });

--- a/test/unit/b01_status_normalization.test.ts
+++ b/test/unit/b01_status_normalization.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { Q7VacuumFeatures } from "../../src/lib/features/vacuum/b01/Q7VacuumFeatures";
+import type { FeatureDependencies } from "../../src/lib/features/baseDeviceFeatures";
+
+function createDeps() {
+	const updateB01DeviceStatus = vi.fn();
+	const setStateChanged = vi.fn().mockResolvedValue(undefined);
+	const ensureState = vi.fn().mockResolvedValue(undefined);
+	const ensureFolder = vi.fn().mockResolvedValue(undefined);
+	const deps: FeatureDependencies = {
+		adapter: {
+			language: "en",
+			translations: {},
+			translationManager: { get: vi.fn((key: string, fallback?: string) => fallback ?? key) },
+			mapManager: { updateB01DeviceStatus },
+			setStateChanged,
+			rLog: vi.fn(),
+			formatRoborockDate: vi.fn((value: number) => String(value)),
+			errorMessage: vi.fn((error: unknown) => error instanceof Error ? error.message : String(error)),
+		} as any,
+		config: {} as any,
+		http_api: {} as any,
+		ensureState,
+		ensureFolder,
+		log: {
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as any,
+	};
+
+	return { deps, updateB01DeviceStatus, setStateChanged };
+}
+
+describe("B01 status normalization", () => {
+	it("writes canonical adapter states from Q7/B01 raw status keys", async () => {
+		const { deps, updateB01DeviceStatus, setStateChanged } = createDeps();
+		const feature = new Q7VacuumFeatures(deps, "duid-q7", "roborock.vacuum.sc01", { staticFeatures: [] });
+
+		await (feature as any).processStatus({
+			quantity: 88,
+			fault: 0,
+			wind: 2,
+			water: 3,
+			work_mode: 1,
+			sweep_type: 1,
+			cleaning_area: 11287,
+		});
+
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.duid-q7.deviceStatus.battery", { val: 88, ack: true });
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.duid-q7.deviceStatus.error_code", { val: 0, ack: true });
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.duid-q7.deviceStatus.fan_power", { val: 2, ack: true });
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.duid-q7.deviceStatus.water_box_mode", { val: 3, ack: true });
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.duid-q7.deviceStatus.mop_mode", { val: 1, ack: true });
+		expect(setStateChanged).toHaveBeenCalledWith("Devices.duid-q7.deviceStatus.clean_area", { val: 112.87, ack: true });
+		expect(updateB01DeviceStatus).toHaveBeenCalledWith("duid-q7", expect.objectContaining({
+			deviceBattery: 88,
+			deviceFault: 0,
+			deviceWorkMode: 1,
+		}));
+	});
+});

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { DeviceManager } from "../../src/lib/deviceManager";
 
 describe("device online state sync from HomeData", () => {
-	it("writes HomeData for offline devices on slow ticks before skipping polling", async () => {
+	it("writes HomeData for offline Q7 devices on slow ticks before skipping polling", async () => {
 		let tick: (() => Promise<void>) | undefined;
 
 		const handler = {
+			b01Variant: "Q7",
 			updateStatus: vi.fn().mockResolvedValue(undefined),
 			updateMap: vi.fn().mockResolvedValue(undefined),
 			updateCleanSummary: vi.fn().mockResolvedValue(undefined),
@@ -18,9 +19,9 @@ describe("device online state sync from HomeData", () => {
 			online: false,
 			deviceStatus: {
 				"122": 100,
-				"125": 83,
-				"126": 100,
-				"127": 42,
+				"125": 98,
+				"126": 4294967249,
+				"127": 97,
 			},
 		}];
 
@@ -32,7 +33,7 @@ describe("device online state sync from HomeData", () => {
 				getDevices: () => devices,
 			},
 			updateDeviceInfo: vi.fn().mockResolvedValue(undefined),
-			getDeviceProtocolVersion: vi.fn().mockResolvedValue("1.0"),
+			getDeviceProtocolVersion: vi.fn().mockResolvedValue("B01"),
 			catchError: vi.fn(),
 			ensureState: vi.fn().mockResolvedValue(undefined),
 			setStateChanged: vi.fn().mockResolvedValue(undefined),
@@ -55,14 +56,15 @@ describe("device online state sync from HomeData", () => {
 		expect(adapter.http_api.updateHomeData).toHaveBeenCalledTimes(1);
 		expect(adapter.updateDeviceInfo).toHaveBeenCalledWith("duid-1", devices);
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.battery", { val: 100, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 83, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", { val: 100, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", { val: 42, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", { val: 98, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", { val: 97, ack: true });
+		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", expect.anything());
 		expect(handler.updateStatus).not.toHaveBeenCalled();
 	});
 
 	it("ignores textual and out-of-range HomeData status attributes because only valid numeric percentages are mapped", async () => {
 		const handler = {
+			b01Variant: "Q7",
 			getCommonConsumable: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 			getCommonDeviceStates: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 		};
@@ -95,7 +97,7 @@ describe("device online state sync from HomeData", () => {
 
 		await manager.updateHomeDataDeviceStatus("duid-1");
 
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", { val: 91, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);
 	});
 });

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -10,12 +10,14 @@ describe("device online state sync from HomeData", () => {
 			updateMap: vi.fn().mockResolvedValue(undefined),
 			updateCleanSummary: vi.fn().mockResolvedValue(undefined),
 			getCommonConsumable: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
+			getCommonDeviceStates: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 		};
 
 		const devices = [{
 			duid: "duid-1",
 			online: false,
 			deviceStatus: {
+				"122": 100,
 				"125": 83,
 				"126": 100,
 				"127": 42,
@@ -52,15 +54,17 @@ describe("device online state sync from HomeData", () => {
 
 		expect(adapter.http_api.updateHomeData).toHaveBeenCalledTimes(1);
 		expect(adapter.updateDeviceInfo).toHaveBeenCalledWith("duid-1", devices);
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.battery", { val: 100, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 83, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", { val: 100, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", { val: 42, ack: true });
 		expect(handler.updateStatus).not.toHaveBeenCalled();
 	});
 
-	it("ignores textual and out-of-range consumable attributes because only valid numeric HomeData percentages are mapped", async () => {
+	it("ignores textual and out-of-range HomeData status attributes because only valid numeric percentages are mapped", async () => {
 		const handler = {
 			getCommonConsumable: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
+			getCommonDeviceStates: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 		};
 		const devices = [{
 			duid: "duid-1",
@@ -70,8 +74,9 @@ describe("device online state sync from HomeData", () => {
 				side_brush_life: 72,
 				filter_life: "65%",
 				ignored_life: 12,
+				"122": 101,
 				"125": 91,
-				"126": "72",
+				"126": 4294967249,
 				"127": 101,
 			},
 		}];
@@ -88,7 +93,7 @@ describe("device online state sync from HomeData", () => {
 		const manager = new DeviceManager(adapter as any);
 		manager.deviceFeatureHandlers.set("duid-1", handler as any);
 
-		await manager.updateConsumablesPercent("duid-1");
+		await manager.updateHomeDataDeviceStatus("duid-1");
 
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -58,7 +58,7 @@ describe("device online state sync from HomeData", () => {
 		expect(handler.updateStatus).not.toHaveBeenCalled();
 	});
 
-	it("ignores textual consumable attributes because only numeric HomeData keys are mapped", async () => {
+	it("ignores textual and out-of-range consumable attributes because only valid numeric HomeData percentages are mapped", async () => {
 		const handler = {
 			getCommonConsumable: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 		};
@@ -91,7 +91,6 @@ describe("device online state sync from HomeData", () => {
 		await manager.updateConsumablesPercent("duid-1");
 
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", { val: 0, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledTimes(2);
+		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);
 	});
 });

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeviceManager } from "../../src/lib/deviceManager";
 
 describe("device online state sync from HomeData", () => {
-	it("writes HomeData for offline Q7 devices on slow ticks before skipping polling", async () => {
+	it("writes HomeData battery but not stale Q7 consumables on slow ticks before skipping polling", async () => {
 		let tick: (() => Promise<void>) | undefined;
 
 		const handler = {
@@ -56,15 +56,16 @@ describe("device online state sync from HomeData", () => {
 		expect(adapter.http_api.updateHomeData).toHaveBeenCalledTimes(1);
 		expect(adapter.updateDeviceInfo).toHaveBeenCalledWith("duid-1", devices);
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.battery", { val: 100, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", { val: 98, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", { val: 97, ack: true });
+		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", expect.anything());
+		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", expect.anything());
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", expect.anything());
+		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);
 		expect(handler.updateStatus).not.toHaveBeenCalled();
 	});
 
 	it("ignores textual and out-of-range HomeData status attributes because only valid numeric percentages are mapped", async () => {
 		const handler = {
-			b01Variant: "Q7",
+			b01Variant: "Q10",
 			getCommonConsumable: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 			getCommonDeviceStates: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
 		};
@@ -97,7 +98,7 @@ describe("device online state sync from HomeData", () => {
 
 		await manager.updateHomeDataDeviceStatus("duid-1");
 
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", { val: 91, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);
 	});
 });

--- a/test/unit/services/B01ConsumableService.test.ts
+++ b/test/unit/services/B01ConsumableService.test.ts
@@ -56,10 +56,10 @@ describe("B01ConsumableService", () => {
 
 		// Create array of correct length filled with dummy data
 		const mockArray = new Array(props.length).fill(0);
-		// main_brush life: 300h. Used: 150h (540000s). Remaining: 150h.
-		if (mainBrushIndex !== -1) mockArray[mainBrushIndex] = 3600 * 150;
-		// side_brush life: 200h. Used: 200h (720000s). Remaining: 0h.
-		if (sideBrushIndex !== -1) mockArray[sideBrushIndex] = 3600 * 200;
+		// main_brush life: 300h. Used: 150h (9000min). Remaining: 150h.
+		if (mainBrushIndex !== -1) mockArray[mainBrushIndex] = 60 * 150;
+		// side_brush life: 200h. Used: 200h (12000min). Remaining: 0h.
+		if (sideBrushIndex !== -1) mockArray[sideBrushIndex] = 60 * 200;
 
 		mockAdapter.requestsHandler.sendRequest.mockResolvedValue(mockArray);
 
@@ -75,9 +75,9 @@ describe("B01ConsumableService", () => {
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_life`, { val: 0, ack: true });
 	});
 
-	it("should process consumable work times and calculate remaining hours", async () => {
+	it("should process consumable used minutes and calculate remaining hours", async () => {
 		const data = {
-			main_brush_work_time: 3600 * 150, // 150 hours used
+			main_brush_work_time: 60 * 150, // 150 hours used
 			// main_brush total life is 300 hours
 			// So expected remaining = 300 - 150 = 150 hours
 		};
@@ -109,7 +109,7 @@ describe("B01ConsumableService", () => {
 
 	it("should handle full usage (0h remaining) correctly", async () => {
 		const data = {
-			filter_work_time: 3600 * 150, // 150 hours used (max is 150 for filter)
+			filter_work_time: 60 * 150, // 150 hours used (max is 150 for filter)
 		};
 		await service.updateConsumables(data);
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.filter_work_time`, { val: 0, ack: true });
@@ -123,5 +123,29 @@ describe("B01ConsumableService", () => {
 		// side_brush life: 200h. Used: 0. Remaining: 200h.
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_work_time`, { val: 200, ack: true });
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_life`, { val: 100, ack: true });
+	});
+
+	it("should match Q7 app values when the robot reports 303 used minutes", async () => {
+		await service.updateConsumables({
+			main_brush_work_time: 303,
+			side_brush_work_time: 303,
+			filter_work_time: 303,
+		});
+
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_work_time`, { val: 295, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_work_time`, { val: 195, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.filter_work_time`, { val: 145, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_life`, { val: 99, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_life`, { val: 98, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.filter_life`, { val: 97, ack: true });
+	});
+
+	it("should keep treating oversized work-time counters as seconds", async () => {
+		await service.updateConsumables({
+			main_brush_work_time: 73044,
+		});
+
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_work_time`, { val: 280, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_life`, { val: 94, ack: true });
 	});
 });

--- a/test/unit/services/B01ConsumableService.test.ts
+++ b/test/unit/services/B01ConsumableService.test.ts
@@ -71,6 +71,8 @@ describe("B01ConsumableService", () => {
 		// Expect State Calculation (Remaining Hours)
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_work_time`, { val: 150, ack: true });
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_work_time`, { val: 0, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_life`, { val: 50, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_life`, { val: 0, ack: true });
 	});
 
 	it("should process consumable work times and calculate remaining hours", async () => {
@@ -88,6 +90,7 @@ describe("B01ConsumableService", () => {
 		// Expect State Calculation (Remaining Hours)
 		expect(mockDeps.ensureState).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_work_time`, expect.objectContaining({ unit: "h" }));
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_work_time`, { val: 150, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.main_brush_life`, { val: 50, ack: true });
 
 		// Expect Reset Button
 		expect(mockDeps.ensureState).toHaveBeenCalledWith(`Devices.${duid}.resetConsumables.reset_main_brush`, expect.objectContaining({ role: "button" }), expect.anything());
@@ -119,5 +122,6 @@ describe("B01ConsumableService", () => {
 		await service.updateConsumables(data);
 		// side_brush life: 200h. Used: 0. Remaining: 200h.
 		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_work_time`, { val: 200, ack: true });
+		expect(mockAdapter.setStateChanged).toHaveBeenCalledWith(`Devices.${duid}.consumables.side_brush_life`, { val: 100, ack: true });
 	});
 });


### PR DESCRIPTION
Closes #1342

## What changed

- Route Q7 B01 protocol 102 replies wrapped in `dps.10001` through the B01 RPC response path.
- Normalize Q7 status aliases and expose battery values consistently.
- Load B01 consumables during the regular online refresh.
- Interpret Q7 `prop.get` consumable counters as used minutes and calculate the same remaining percentages as the Roborock app.
- Prevent stale or incomplete Q7 HomeData consumable fields from overwriting the live `prop.get` values.
- Keep HomeData battery synchronization and the generic HomeData consumable fallback for other variants.

## Root cause

The Q7 Pro sends live B01 RPC replies through `dps.10001`, while its HomeData consumable fields are stale or incomplete. The adapter did not consistently resolve that reply path and later allowed HomeData values to overwrite the correct live consumable values.

## User impact

The reporter confirmed that map rendering, battery status, and consumable percentages now work and match the device/app data.

## Validation

- `npm run typecheck`
- `npx vitest run --maxWorkers=1 --fileParallelism=false` (44 files, 274 tests passed)
- Reporter validation on a Roborock Q7 Pro
