### PR TITLE
fix: restore raw HomeData device status states

### DIFF
--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -91,6 +91,7 @@ function createFeaturesForModel(adapter: Roborock, duid: string, robotModel: str
 }
 
 export class DeviceManager {
+	private static readonly ZEO_ONE_MODEL = "roborock.wm.a102";
 	private adapter: Roborock;
 	private static readonly HOME_DATA_DEVICE_STATUS_MAP: Record<string, string> = {
 		"122": "battery",
@@ -559,5 +560,116 @@ export class DeviceManager {
 			await this.adapter.ensureState(`Devices.${duid}.consumables.${mappedName}`, common || {});
 			await this.adapter.setStateChanged(`Devices.${duid}.consumables.${mappedName}`, { val: value, ack: true });
 		}
+
+		await this.updateZeoOneCustomProgram(duid, status, statusPath);
+	}
+
+	/**
+	 * The Zeo One AppPlugin encodes its custom-program selection in HomeData DP 222.
+	 * Keep DP 222 as the lossless source and expose the same decoded fields the app uses.
+	 */
+	private async updateZeoOneCustomProgram(duid: string, status: Record<string, unknown>, statusPath: string): Promise<void> {
+		if (this.adapter.http_api.getRobotModel?.(duid) !== DeviceManager.ZEO_ONE_MODEL) return;
+
+		const rawProgram = status["222"];
+		if (typeof rawProgram !== "number" || !Number.isSafeInteger(rawProgram) || rawProgram < 0) return;
+
+		const rawTotalTime = status["239"];
+		const totalTime = typeof rawTotalTime === "number" && Number.isFinite(rawTotalTime) && rawTotalTime >= 0
+			? rawTotalTime
+			: undefined;
+		const program = rawProgram & 0xff;
+		const mode = (rawProgram & 0x300) >> 8;
+		const temperatureLevel = (rawProgram & 0x1c00) >> 10;
+		const rinse = (rawProgram & 0xe000) >> 13;
+		const spinLevel = (rawProgram & 0x70000) >> 16;
+		const dryingMode = (rawProgram & 0x380000) >> 19;
+		const soakLevel = (rawProgram & 0x1c00000) >> 22;
+		const dryCareMode = (rawProgram & 0xe000000) >> 25;
+		const customProgramPath = `${statusPath}.custom_program`;
+
+		const localized = (en: string, de: string): string | ioBroker.StringOrTranslated => ({ en, de });
+		const valueText = (en: string, de: string): string => this.adapter.language?.toLowerCase().startsWith("de") ? de : en;
+		const programNames: Record<number, { en: string; de: string }> = {
+			2: { en: "Quick", de: "Schnell" },
+			23: { en: "Cotton/Linen", de: "Baumwolle/Leinen" },
+		};
+		const programName = programNames[program] ?? { en: `Program ${program}`, de: `Programm ${program}` };
+		const temperatureByLevel: Record<number, number> = { 1: 0, 2: 30, 3: 40, 4: 60, 5: 90, 6: 20 };
+		const spinByLevel: Record<number, number> = { 1: 0, 2: 400, 3: 600, 4: 800, 5: 1000, 6: 1200, 7: 1400 };
+		const soakByLevel: Record<number, number> = { 0: 0, 1: 5, 2: 10, 3: 15, 4: 20 };
+		const dryingDegreeByMode: Record<number, number> = { 0: 0, 1: 2, 2: 1, 3: 3 };
+
+		await this.adapter.ensureFolder(customProgramPath);
+		const states: Array<{ id: string; common: Partial<ioBroker.StateCommon>; value: ioBroker.StateValue }> = [
+			{
+				id: "program",
+				common: { name: localized("Custom program", "Benutzerdefiniertes Programm"), type: "number", read: true, write: false },
+				value: program,
+			},
+			{
+				id: "program_name",
+				common: { name: localized("Custom program name", "Name des benutzerdefinierten Programms"), type: "string", read: true, write: false },
+				value: valueText(programName.en, programName.de),
+			},
+			{
+				id: "mode",
+				common: {
+					name: localized("Mode", "Modus"), type: "number", read: true, write: false,
+					states: { 1: valueText("Wash", "Waschen"), 2: valueText("Wash and dry", "Waschen und Trocknen"), 3: valueText("Dry", "Trocknen") },
+				},
+				value: mode,
+			},
+			{
+				id: "temperature",
+				common: { name: localized("Temperature", "Temperatur"), type: "number", unit: "°C", read: true, write: false },
+				value: temperatureByLevel[temperatureLevel] ?? temperatureLevel,
+			},
+			{
+				id: "rinse_cycles",
+				common: { name: localized("Rinse cycles", "Spülzyklen"), type: "number", read: true, write: false },
+				value: rinse,
+			},
+			{
+				id: "spin_speed",
+				common: { name: localized("Spin speed", "Schleuderdrehzahl"), type: "number", unit: "rpm", read: true, write: false },
+				value: spinByLevel[spinLevel] ?? spinLevel,
+			},
+			{
+				id: "drying_degree",
+				common: {
+					name: localized("Drying degree", "Trocknungsgrad"), type: "number", read: true, write: false,
+					states: { 0: valueText("Off", "Aus"), 1: valueText("Low", "Niedrig"), 2: valueText("Medium", "Mittel"), 3: valueText("High", "Hoch") },
+				},
+				value: dryingDegreeByMode[dryingMode] ?? dryingMode,
+			},
+			{
+				id: "soak_duration",
+				common: { name: localized("Soak duration", "Dauer des Einweichens"), type: "number", unit: "min", read: true, write: false },
+				value: soakByLevel[soakLevel] ?? soakLevel,
+			},
+			{
+				id: "dry_care_mode",
+				common: {
+					name: localized("Dry care", "Pflege beim Trocknen"), type: "number", read: true, write: false,
+					states: { 0: valueText("Off", "Aus"), 1: valueText("Soft", "Sanft"), 2: valueText("Normal", "Normal") },
+				},
+				value: dryCareMode,
+			},
+		];
+
+		if (totalTime !== undefined) {
+			states.push({
+				id: "total_time",
+				common: { name: localized("Total program time", "Gesamtdauer des Programms"), type: "number", unit: "min", read: true, write: false },
+				value: totalTime,
+			});
+		}
+
+		await Promise.all(states.map(async ({ id, common, value }) => {
+			const path = `${customProgramPath}.${id}`;
+			await this.adapter.ensureState(path, common);
+			await this.adapter.setStateChanged(path, { val: value, ack: true });
+		}));
 	}
 }

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -532,7 +532,8 @@ export class DeviceManager {
 		for (const [attribute, value] of Object.entries(status)) {
 			if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
 				const path = `${statusPath}.${attribute}`;
-				await this.adapter.ensureState(path, { name: attribute, type: typeof value, read: true, write: false });
+				const type: ioBroker.CommonType = typeof value === "string" ? "string" : typeof value === "number" ? "number" : "boolean";
+				await this.adapter.ensureState(path, { name: attribute, type, read: true, write: false });
 				await this.adapter.setStateChanged(path, { val: value, ack: true });
 			}
 

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -90,21 +90,10 @@ function createFeaturesForModel(adapter: Roborock, duid: string, robotModel: str
 	return handler;
 }
 
-type HomeDataStatusDefinition = {
-	name: string;
-	common?: Partial<ioBroker.StateCommon>;
-};
-
 export class DeviceManager {
 	private adapter: Roborock;
 	private static readonly HOME_DATA_DEVICE_STATUS_MAP: Record<string, string> = {
 		"122": "battery",
-	};
-	private static readonly MODEL_HOME_DATA_DEVICE_STATUS_MAP: Record<string, Record<string, HomeDataStatusDefinition>> = {
-		"roborock.wm.a102": {
-			// The cloud reports an opaque numeric identifier for the saved app-program shortcut.
-			"222": { name: "app_program", common: { name: "App Program ID", type: "number", role: "value", read: true, write: false } },
-		},
 	};
 	private static readonly HOME_DATA_CONSUMABLE_MAP: Record<string, string> = {
 		"125": "main_brush_life",
@@ -130,14 +119,6 @@ export class DeviceManager {
 			: DeviceManager.HOME_DATA_CONSUMABLE_MAP;
 	}
 
-	private getHomeDataStatusDefinition(duid: string, attribute: string): HomeDataStatusDefinition | undefined {
-		const model = this.adapter.http_api.getRobotModel(duid);
-		const modelSpecificDefinition = model ? DeviceManager.MODEL_HOME_DATA_DEVICE_STATUS_MAP[model]?.[attribute] : undefined;
-		if (modelSpecificDefinition) return modelSpecificDefinition;
-
-		const genericName = DeviceManager.HOME_DATA_DEVICE_STATUS_MAP[attribute];
-		return genericName ? { name: genericName } : undefined;
-	}
 
 	/**
 	 * Initializes devices from HTTP API.
@@ -557,15 +538,13 @@ export class DeviceManager {
 				await this.adapter.setStateChanged(path, { val: value, ack: true });
 			}
 
-			const statusDefinition = this.getHomeDataStatusDefinition(duid, attribute);
-			if (statusDefinition) {
-				if (typeof value !== "number" || !Number.isInteger(value) || value < 0) continue;
-				// Generic status aliases are percentages; model-specific definitions may use larger opaque IDs.
-				if (!statusDefinition.common && value > 100) continue;
-				const common = statusDefinition.common || handler.getCommonDeviceStates(statusDefinition.name);
+			const statusName = DeviceManager.HOME_DATA_DEVICE_STATUS_MAP[attribute];
+			if (statusName) {
+				if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 100) continue;
+				const common = handler.getCommonDeviceStates(statusName);
 
-				await this.adapter.ensureState(`${statusPath}.${statusDefinition.name}`, common || {});
-				await this.adapter.setStateChanged(`${statusPath}.${statusDefinition.name}`, { val: value, ack: true });
+				await this.adapter.ensureState(`${statusPath}.${statusName}`, common || {});
+				await this.adapter.setStateChanged(`${statusPath}.${statusName}`, { val: value, ack: true });
 				continue;
 			}
 

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -512,24 +512,37 @@ export class DeviceManager {
 	}
 
 	/**
-	 * Applies numeric device.status values from cloud HomeData.
+	 * Applies all scalar device.status values from cloud HomeData.
+	 *
+	 * HomeData is the only status source for some product categories. Preserve its
+	 * raw keys under deviceStatus so unknown devices do not silently lose values;
+	 * named device and consumable states remain supplemental compatibility aliases.
 	 */
 	public async updateHomeDataDeviceStatus(duid: string, devices = this.adapter.http_api.getDevices()): Promise<void> {
 		const handler = this.deviceFeatureHandlers.get(duid);
 		if (!handler) return;
 
 		const device = devices.find((d) => d.duid === duid);
-		if (!device?.deviceStatus) return; // 'deviceStatus' exists on Device type
+		if (!device?.deviceStatus) return;
 		const status = device.deviceStatus as Record<string, unknown>;
+		const statusPath = `Devices.${duid}.deviceStatus`;
+
+		await this.adapter.ensureFolder(statusPath);
 
 		for (const [attribute, value] of Object.entries(status)) {
+			if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+				const path = `${statusPath}.${attribute}`;
+				await this.adapter.ensureState(path, { name: attribute, type: typeof value, read: true, write: false });
+				await this.adapter.setStateChanged(path, { val: value, ack: true });
+			}
+
 			const statusName = DeviceManager.HOME_DATA_DEVICE_STATUS_MAP[attribute];
 			if (statusName) {
 				if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 100) continue;
 				const common = handler.getCommonDeviceStates(statusName);
 
-				await this.adapter.ensureState(`Devices.${duid}.deviceStatus.${statusName}`, common || {});
-				await this.adapter.setStateChanged(`Devices.${duid}.deviceStatus.${statusName}`, { val: value, ack: true });
+				await this.adapter.ensureState(`${statusPath}.${statusName}`, common || {});
+				await this.adapter.setStateChanged(`${statusPath}.${statusName}`, { val: value, ack: true });
 				continue;
 			}
 
@@ -539,7 +552,7 @@ export class DeviceManager {
 			if (typeof value !== "number" || !Number.isInteger(value)) continue;
 			if (value < 0 || value > 100) continue;
 
-			const common = handler.getCommonConsumable(mappedName); // Use mapped name
+			const common = handler.getCommonConsumable(mappedName);
 
 			await this.adapter.ensureState(`Devices.${duid}.consumables.${mappedName}`, common || {});
 			await this.adapter.setStateChanged(`Devices.${duid}.consumables.${mappedName}`, { val: value, ack: true });

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -90,10 +90,21 @@ function createFeaturesForModel(adapter: Roborock, duid: string, robotModel: str
 	return handler;
 }
 
+type HomeDataStatusDefinition = {
+	name: string;
+	common?: Partial<ioBroker.StateCommon>;
+};
+
 export class DeviceManager {
 	private adapter: Roborock;
 	private static readonly HOME_DATA_DEVICE_STATUS_MAP: Record<string, string> = {
 		"122": "battery",
+	};
+	private static readonly MODEL_HOME_DATA_DEVICE_STATUS_MAP: Record<string, Record<string, HomeDataStatusDefinition>> = {
+		"roborock.wm.a102": {
+			// The cloud reports an opaque numeric identifier for the saved app-program shortcut.
+			"222": { name: "app_program", common: { name: "App Program ID", type: "number", role: "value", read: true, write: false } },
+		},
 	};
 	private static readonly HOME_DATA_CONSUMABLE_MAP: Record<string, string> = {
 		"125": "main_brush_life",
@@ -117,6 +128,15 @@ export class DeviceManager {
 		return (handler as unknown as { b01Variant?: string }).b01Variant === "Q7"
 			? DeviceManager.Q7_HOME_DATA_CONSUMABLE_MAP
 			: DeviceManager.HOME_DATA_CONSUMABLE_MAP;
+	}
+
+	private getHomeDataStatusDefinition(duid: string, attribute: string): HomeDataStatusDefinition | undefined {
+		const model = this.adapter.http_api.getRobotModel(duid);
+		const modelSpecificDefinition = model ? DeviceManager.MODEL_HOME_DATA_DEVICE_STATUS_MAP[model]?.[attribute] : undefined;
+		if (modelSpecificDefinition) return modelSpecificDefinition;
+
+		const genericName = DeviceManager.HOME_DATA_DEVICE_STATUS_MAP[attribute];
+		return genericName ? { name: genericName } : undefined;
 	}
 
 	/**
@@ -537,13 +557,15 @@ export class DeviceManager {
 				await this.adapter.setStateChanged(path, { val: value, ack: true });
 			}
 
-			const statusName = DeviceManager.HOME_DATA_DEVICE_STATUS_MAP[attribute];
-			if (statusName) {
-				if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 100) continue;
-				const common = handler.getCommonDeviceStates(statusName);
+			const statusDefinition = this.getHomeDataStatusDefinition(duid, attribute);
+			if (statusDefinition) {
+				if (typeof value !== "number" || !Number.isInteger(value) || value < 0) continue;
+				// Generic status aliases are percentages; model-specific definitions may use larger opaque IDs.
+				if (!statusDefinition.common && value > 100) continue;
+				const common = statusDefinition.common || handler.getCommonDeviceStates(statusDefinition.name);
 
-				await this.adapter.ensureState(`${statusPath}.${statusName}`, common || {});
-				await this.adapter.setStateChanged(`${statusPath}.${statusName}`, { val: value, ack: true });
+				await this.adapter.ensureState(`${statusPath}.${statusDefinition.name}`, common || {});
+				await this.adapter.setStateChanged(`${statusPath}.${statusDefinition.name}`, { val: value, ack: true });
 				continue;
 			}
 

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -31,7 +31,6 @@ describe("device online state sync from HomeData", () => {
 			http_api: {
 				updateHomeData: vi.fn().mockResolvedValue(undefined),
 				getDevices: () => devices,
-				getRobotModel: vi.fn(() => "roborock.vacuum.sc01"),
 			},
 			updateDeviceInfo: vi.fn().mockResolvedValue(undefined),
 			getDeviceProtocolVersion: vi.fn().mockResolvedValue("B01"),
@@ -91,7 +90,6 @@ describe("device online state sync from HomeData", () => {
 			config: { updateInterval: 5 },
 			http_api: {
 				getDevices: () => devices,
-				getRobotModel: vi.fn(() => "roborock.wm.a102"),
 			},
 			ensureState: vi.fn().mockResolvedValue(undefined),
 			ensureFolder: vi.fn().mockResolvedValue(undefined),
@@ -106,10 +104,8 @@ describe("device online state sync from HomeData", () => {
 		expect(adapter.ensureFolder).toHaveBeenCalledWith("Devices.duid-1.deviceStatus");
 		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.200", expect.objectContaining({ type: "number" }));
 		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.10005", expect.objectContaining({ type: "string" }));
-		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.app_program", expect.objectContaining({ name: "App Program ID", type: "number", read: true, write: false }));
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.200", { val: 1, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.222", { val: 936449, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.app_program", { val: 936449, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.10005", { val: "{\\\"ssid\\\":\\\"MagicSignal\\\"}", ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.deviceStatus.nested", expect.anything());

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -31,6 +31,7 @@ describe("device online state sync from HomeData", () => {
 			http_api: {
 				updateHomeData: vi.fn().mockResolvedValue(undefined),
 				getDevices: () => devices,
+				getRobotModel: vi.fn(() => "roborock.vacuum.sc01"),
 			},
 			updateDeviceInfo: vi.fn().mockResolvedValue(undefined),
 			getDeviceProtocolVersion: vi.fn().mockResolvedValue("B01"),
@@ -90,6 +91,7 @@ describe("device online state sync from HomeData", () => {
 			config: { updateInterval: 5 },
 			http_api: {
 				getDevices: () => devices,
+				getRobotModel: vi.fn(() => "roborock.wm.a102"),
 			},
 			ensureState: vi.fn().mockResolvedValue(undefined),
 			ensureFolder: vi.fn().mockResolvedValue(undefined),
@@ -104,8 +106,10 @@ describe("device online state sync from HomeData", () => {
 		expect(adapter.ensureFolder).toHaveBeenCalledWith("Devices.duid-1.deviceStatus");
 		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.200", expect.objectContaining({ type: "number" }));
 		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.10005", expect.objectContaining({ type: "string" }));
+		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.app_program", expect.objectContaining({ name: "App Program ID", type: "number", read: true, write: false }));
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.200", { val: 1, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.222", { val: 936449, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.app_program", { val: 936449, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.10005", { val: "{\\\"ssid\\\":\\\"MagicSignal\\\"}", ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.deviceStatus.nested", expect.anything());

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -36,6 +36,7 @@ describe("device online state sync from HomeData", () => {
 			getDeviceProtocolVersion: vi.fn().mockResolvedValue("B01"),
 			catchError: vi.fn(),
 			ensureState: vi.fn().mockResolvedValue(undefined),
+			ensureFolder: vi.fn().mockResolvedValue(undefined),
 			setStateChanged: vi.fn().mockResolvedValue(undefined),
 			setInterval: vi.fn((callback: () => Promise<void>) => {
 				tick = callback;
@@ -55,15 +56,18 @@ describe("device online state sync from HomeData", () => {
 
 		expect(adapter.http_api.updateHomeData).toHaveBeenCalledTimes(1);
 		expect(adapter.updateDeviceInfo).toHaveBeenCalledWith("duid-1", devices);
+		expect(adapter.ensureFolder).toHaveBeenCalledWith("Devices.duid-1.deviceStatus");
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.122", { val: 100, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.125", { val: 98, ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.battery", { val: 100, ack: true });
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.side_brush_life", expect.anything());
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.filter_life", expect.anything());
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", expect.anything());
-		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);
+		expect(adapter.setStateChanged).toHaveBeenCalledTimes(5);
 		expect(handler.updateStatus).not.toHaveBeenCalled();
 	});
 
-	it("ignores textual and out-of-range HomeData status attributes because only valid numeric percentages are mapped", async () => {
+	it("preserves every scalar HomeData status field while keeping validated aliases", async () => {
 		const handler = {
 			b01Variant: "Q10",
 			getCommonConsumable: vi.fn((id: string) => ({ type: "number", unit: "%", name: id })),
@@ -73,14 +77,12 @@ describe("device online state sync from HomeData", () => {
 			duid: "duid-1",
 			online: true,
 			deviceStatus: {
-				main_brush_life: "91",
-				side_brush_life: 72,
-				filter_life: "65%",
-				ignored_life: 12,
+				"200": 1,
+				"222": 936449,
+				"10005": "{\\\"ssid\\\":\\\"MagicSignal\\\"}",
 				"122": 101,
 				"125": 91,
-				"126": 4294967249,
-				"127": 101,
+				nested: { ignored: true },
 			},
 		}];
 
@@ -90,6 +92,7 @@ describe("device online state sync from HomeData", () => {
 				getDevices: () => devices,
 			},
 			ensureState: vi.fn().mockResolvedValue(undefined),
+			ensureFolder: vi.fn().mockResolvedValue(undefined),
 			setStateChanged: vi.fn().mockResolvedValue(undefined),
 		};
 
@@ -98,7 +101,13 @@ describe("device online state sync from HomeData", () => {
 
 		await manager.updateHomeDataDeviceStatus("duid-1");
 
+		expect(adapter.ensureFolder).toHaveBeenCalledWith("Devices.duid-1.deviceStatus");
+		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.200", expect.objectContaining({ type: "number" }));
+		expect(adapter.ensureState).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.10005", expect.objectContaining({ type: "string" }));
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.200", { val: 1, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.222", { val: 936449, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.deviceStatus.10005", { val: "{\\\"ssid\\\":\\\"MagicSignal\\\"}", ack: true });
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
-		expect(adapter.setStateChanged).toHaveBeenCalledTimes(1);
+		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.deviceStatus.nested", expect.anything());
 	});
 });

--- a/test/unit/device_online_homedata_sync.test.ts
+++ b/test/unit/device_online_homedata_sync.test.ts
@@ -110,4 +110,48 @@ describe("device online state sync from HomeData", () => {
 		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.duid-1.consumables.main_brush_life", { val: 91, ack: true });
 		expect(adapter.setStateChanged).not.toHaveBeenCalledWith("Devices.duid-1.deviceStatus.nested", expect.anything());
 	});
+
+	it("decodes Zeo One custom-program DP 222 without replacing its raw HomeData value", async () => {
+		const handler = {
+			getCommonConsumable: vi.fn(),
+			getCommonDeviceStates: vi.fn(),
+		};
+		const devices = [{
+			duid: "zeo-one",
+			online: true,
+			deviceStatus: {
+				"222": 994818,
+				"239": 75,
+			},
+		}];
+		const adapter = {
+			language: "de",
+			http_api: {
+				getDevices: () => devices,
+				getRobotModel: vi.fn().mockReturnValue("roborock.wm.a102"),
+			},
+			ensureState: vi.fn().mockResolvedValue(undefined),
+			ensureFolder: vi.fn().mockResolvedValue(undefined),
+			setStateChanged: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const manager = new DeviceManager(adapter as any);
+		manager.deviceFeatureHandlers.set("zeo-one", handler as any);
+
+		await manager.updateHomeDataDeviceStatus("zeo-one");
+
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.222", { val: 994818, ack: true });
+		expect(adapter.ensureState).toHaveBeenCalledWith(
+			"Devices.zeo-one.deviceStatus.custom_program.temperature",
+			expect.objectContaining({ name: { en: "Temperature", de: "Temperatur" }, type: "number", unit: "°C" }),
+		);
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.program", { val: 2, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.program_name", { val: "Schnell", ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.mode", { val: 2, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.temperature", { val: 40, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.rinse_cycles", { val: 1, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.spin_speed", { val: 1400, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.drying_degree", { val: 2, ack: true });
+		expect(adapter.setStateChanged).toHaveBeenCalledWith("Devices.zeo-one.deviceStatus.custom_program.total_time", { val: 75, ack: true });
+	});
 });


### PR DESCRIPTION
## Ursache

Die zentrale HomeData-Synchronisation legte nur bekannte, benannte Statuswerte an und verwarf alle übrigen Felder aus `deviceStatus`. Bei der Zeo One waren die Kennzahlen dadurch nur noch als JSON in `deviceInfo.deviceStatus` sichtbar.

## Änderung

- schreibt jeden skalaren HomeData-Statuswert wieder nach `Devices.<DUID>.deviceStatus.<Kennzahl>`
- behält die bestehenden, semantisch benannten Status- und Verbrauchszustände als zusätzliche Aliase bei
- ergänzt einen Regressionstest für die gemeldeten Kennzahlen und JSON-Zeichenketten

Fixes #1378