### PR TITLE
fix: preserve dock error compatibility

### DIFF
--- a/lib/protocols/roborock_error_codes.json
+++ b/lib/protocols/roborock_error_codes.json
@@ -1515,7 +1515,7 @@
       "labelKeys": [
         "error_95_title"
       ],
-      "fallback": "拖布支架安装失败"
+      "fallback": "Mop cloth mount installation failed"
     },
     "97": {
       "types": [

--- a/src/lib/features/vacuum/a179_features.test.ts
+++ b/src/lib/features/vacuum/a179_features.test.ts
@@ -1443,6 +1443,21 @@ describe("A179Features", () => {
 		});
 	});
 
+	it("derives the dock error flag when processing a status payload", async () => {
+		const feature = new A179Features(depsMock, "duid1");
+
+		await feature.processStatus({ dock_error_status: 38 });
+
+		expect(adapterMock.setStateChanged).toHaveBeenCalledWith("Devices.duid1.deviceStatus.dock_error_status", {
+			val: 38,
+			ack: true,
+		});
+		expect(adapterMock.setStateChanged).toHaveBeenCalledWith("Devices.duid1.deviceStatus.hasDockError", {
+			val: true,
+			ack: true,
+		});
+	});
+
 	it("derives Home Security and monitor flags from source-backed status fields", async () => {
 		const feature = new A179Features(depsMock, "duid1");
 

--- a/src/lib/features/vacuum/a179_features.ts
+++ b/src/lib/features/vacuum/a179_features.ts
@@ -2007,7 +2007,7 @@ export class A179Features extends V1VacuumFeatures {
 		}
 
 		if (key === "dock_error_status") {
-			await this.updateDerivedDockErrorStatus(val);
+			await this.afterDockErrorStatusUpdated(val);
 			return;
 		}
 
@@ -3799,7 +3799,7 @@ export class A179Features extends V1VacuumFeatures {
 		}
 	}
 
-	private async updateDerivedDockErrorStatus(rawDockErrorStatus: unknown): Promise<void> {
+	protected override async afterDockErrorStatusUpdated(rawDockErrorStatus: unknown): Promise<void> {
 		const dockErrorStatus = Number(rawDockErrorStatus);
 		if (!Number.isFinite(dockErrorStatus)) {
 			return;

--- a/src/lib/features/vacuum/adapterErrorMapping.test.ts
+++ b/src/lib/features/vacuum/adapterErrorMapping.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { ADAPTER_ERROR_MAPPING, ADAPTER_ERRORS_EN, getLocalizedErrorStates } from "./adapterErrorMapping";
+
+describe("adapter error mapping", () => {
+	it("preserves adapter legacy code 254 across protocol-specific state builders", () => {
+		expect(ADAPTER_ERROR_MAPPING).not.toHaveProperty("254");
+		expect(ADAPTER_ERRORS_EN["254"]).toBe("Bin full");
+		expect(getLocalizedErrorStates({ get: () => "" })["254"]).toBe("Bin full");
+	});
+
+	it("uses the corrected English fallback for error 95", () => {
+		expect(ADAPTER_ERRORS_EN["95"]).toBe("Mop cloth mount installation failed");
+	});
+});

--- a/src/lib/features/vacuum/adapterErrorMapping.ts
+++ b/src/lib/features/vacuum/adapterErrorMapping.ts
@@ -20,25 +20,36 @@ interface TranslationLookup {
 
 const ERROR_CODE_DEFINITIONS = (errorCodeDataset as ErrorCodeDataset).codes;
 
+/**
+ * Codes retained for compatibility with the adapter's established device states.
+ * They must win over equally numbered AppPlugin UI messages in every protocol.
+ */
+const LEGACY_ERROR_STATE_OVERRIDES: Record<string, string> = {
+	"254": "Bin full",
+};
+
 export const ADAPTER_ERROR_MAPPING: Record<number, string> = Object.fromEntries(
 	Object.entries(ERROR_CODE_DEFINITIONS)
-		.filter(([, definition]) => definition.labelKeys.length > 0)
+		.filter(([code, definition]) => definition.labelKeys.length > 0 && !(code in LEGACY_ERROR_STATE_OVERRIDES))
 		.map(([code, definition]) => [Number(code), definition.labelKeys[0]]),
 );
 
 export const ADAPTER_ERRORS_EN: Record<string, string> = Object.fromEntries(
-	Object.entries(ERROR_CODE_DEFINITIONS).map(([code, definition]) => [code, definition.fallback]),
+	[...Object.entries(ERROR_CODE_DEFINITIONS).map(([code, definition]) => [code, definition.fallback]), ...Object.entries(LEGACY_ERROR_STATE_OVERRIDES)],
 );
 
 /** Resolves the shared AppPlugin namespace used by error_code and dock_error_status. */
 export function getLocalizedErrorStates(translationLookup: TranslationLookup): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(ERROR_CODE_DEFINITIONS).map(([code, definition]) => {
-			for (const key of definition.labelKeys) {
-				const translated = translationLookup.get(key, "");
-				if (translated && translated !== key) return [code, translated];
-			}
-			return [code, definition.fallback];
-		}),
-	);
+	return {
+		...Object.fromEntries(
+			Object.entries(ERROR_CODE_DEFINITIONS).map(([code, definition]) => {
+				for (const key of definition.labelKeys) {
+					const translated = translationLookup.get(key, "");
+					if (translated && translated !== key) return [code, translated];
+				}
+				return [code, definition.fallback];
+			}),
+		),
+		...LEGACY_ERROR_STATE_OVERRIDES,
+	};
 }

--- a/src/lib/features/vacuum/v1VacuumFeatures.ts
+++ b/src/lib/features/vacuum/v1VacuumFeatures.ts
@@ -832,6 +832,7 @@ export class V1VacuumFeatures extends BaseDeviceFeatures {
 			dock_error_status: async (val) => {
 				await this.deps.ensureState(`Devices.${this.duid}.deviceStatus.dock_error_status`, { type: "number", states: localizedErrorStates });
 				await this.deps.adapter.setStateChanged(`Devices.${this.duid}.deviceStatus.dock_error_status`, { val, ack: true });
+				await this.afterDockErrorStatusUpdated(val);
 			},
     		fan_power: async (val) => {
     			await this.deps.ensureState(`Devices.${this.duid}.deviceStatus.fan_power`, { type: "number", states: this.profile.mappings.fan_power });
@@ -868,7 +869,12 @@ export class V1VacuumFeatures extends BaseDeviceFeatures {
     		}
     	}
 
-    	await Promise.all(promises);
+		await Promise.all(promises);
+	}
+
+	/** Allows device-specific profiles to derive states from dock_error_status. */
+	protected async afterDockErrorStatusUpdated(_dockErrorStatus: unknown): Promise<void> {
+		// Default profiles do not derive additional states.
 	}
 
 	protected getDynamicFeatures(): Set<Feature> {


### PR DESCRIPTION
Follow-up to #1361 / #1359.

- Restores A179 `hasDockError` derivation for both status processing paths.
- Preserves the established `254 = Bin full` state across V1 and B01.
- Corrects the English AppPlugin source and generated fallback for error 95.

Tests: `npm run lint`, `npm run typecheck`, `npm run test:unit`
